### PR TITLE
Fixed error in derive and added test for this error

### DIFF
--- a/mem_dbg-derive/src/lib.rs
+++ b/mem_dbg-derive/src/lib.rs
@@ -82,7 +82,7 @@ pub fn mem_dbg_mem_size(input: TokenStream) -> TokenStream {
                 impl #impl_generics mem_dbg::MemSize for #input_ident #ty_generics #where_clause {
                     fn mem_size(&self, _memsize_flags: mem_dbg::SizeFlags) -> usize {
                         let mut bytes = core::mem::size_of::<Self>();
-                        #(bytes += <#fields_ty as MemSize>::mem_size(&self.#fields_ident, _memsize_flags) - core::mem::size_of::<#fields_ty>();)*
+                        #(bytes += <#fields_ty as mem_dbg::MemSize>::mem_size(&self.#fields_ident, _memsize_flags) - core::mem::size_of::<#fields_ty>();)*
                         bytes
                     }
                 }
@@ -108,7 +108,7 @@ pub fn mem_dbg_mem_size(input: TokenStream) -> TokenStream {
                                 let field_ident = &field.ident;
                                 let field_ty = field.ty.to_token_stream();
                                 var_args_size.extend([quote! {
-                                    + <#field_ty as MemSize>::mem_size(#field_ident, _memsize_flags) - core::mem::size_of::<#field_ty>()
+                                    + <#field_ty as mem_dbg::MemSize>::mem_size(#field_ident, _memsize_flags) - core::mem::size_of::<#field_ty>()
                                 }]);
                                 args.extend([field_ident.to_token_stream()]);
                                 args.extend([quote! {,}]);
@@ -129,7 +129,7 @@ pub fn mem_dbg_mem_size(input: TokenStream) -> TokenStream {
                             .to_token_stream();
                             let field_ty = field.ty.to_token_stream();
                             var_args_size.extend([quote! {
-                                + <#field_ty as MemSize>::mem_size(#ident, _memsize_flags) - core::mem::size_of::<#field_ty>()
+                                + <#field_ty as mem_dbg::MemSize>::mem_size(#ident, _memsize_flags) - core::mem::size_of::<#field_ty>()
                             }]);
                             args.extend([ident]);
                             args.extend([quote! {,}]);

--- a/mem_dbg/tests/test_mem_size_no_import.rs
+++ b/mem_dbg/tests/test_mem_size_no_import.rs
@@ -1,0 +1,11 @@
+//! Test suite to verify whether derive works properly when MemSize is not imported outside of the derive.
+
+#[derive(mem_dbg::MemSize, mem_dbg::MemDbg)]
+struct MyTestStruct(i32);
+
+#[test]
+fn test_mem_size_no_import() {
+    let my_test_struct = MyTestStruct(42);
+    let mem_size = <MyTestStruct as mem_dbg::MemSize>::mem_size(&my_test_struct, mem_dbg::SizeFlags::default());
+    assert_eq!(mem_size, 4);
+}

--- a/mem_dbg/tests/test_mem_size_no_import.rs
+++ b/mem_dbg/tests/test_mem_size_no_import.rs
@@ -6,6 +6,9 @@ struct MyTestStruct(i32);
 #[test]
 fn test_mem_size_no_import() {
     let my_test_struct = MyTestStruct(42);
-    let mem_size = <MyTestStruct as mem_dbg::MemSize>::mem_size(&my_test_struct, mem_dbg::SizeFlags::default());
+    let mem_size = <MyTestStruct as mem_dbg::MemSize>::mem_size(
+        &my_test_struct,
+        mem_dbg::SizeFlags::default(),
+    );
     assert_eq!(mem_size, 4);
 }


### PR DESCRIPTION
Previously, I wrote `<T as MemSize>::mem_size` in the derive, but `MemSize` is not guaranteed to be in scope and is meant to be called as `<T as mem_dbg::MemSize>::mem_size`. I have fixed that and added a test to verify that such a thing does not represent itself in the future.