### PR TITLE
Added minimal support for some of union cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,16 @@ struct Data<A> {
 }
 
 #[derive(MemSize, MemDbg)]
+union SingletonUnion<A: Copy> {
+    a: A
+}
+
+#[derive(MemSize, MemDbg)]
 enum TestEnum {
     Unit,
     Unit2(),
     Unit3 {},
+    Union(SingletonUnion<u8>),
     Unnamed(usize, u8),
     Named { first: usize, second: u8 },
 }

--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ capacity: 1207
 - `BTreeMap`, and `BTreeSet`, are not currently supported as we still have to
   figure out a way to precisely measure their memory size and capacity.
 
+- Regarding `union`s, we only support completely the special case of the single
+  field `union`, for which we implement both the derive macros `MemSize`/`MemDbg`.
+  For the more complex cases of unions with multiple fields, we only provide the
+  `MemSize` derive macro with partial support, excluding support for the
+  `SizeFlags::FOLLOW_REFS` flag. If full support for derive macros `MemSize`/`MemDbg`
+  in the case of an union with multiple fields, one can implement the traits manually.
+  
+
 [`MemDbg`]: <https://docs.rs/mem_dbg/latest/mem_dbg/trait.MemDbg.html>
 [`MemSize`]: <https://docs.rs/mem_dbg/latest/mem_dbg/trait.MemSize.html>
 [`std::mem::size_of`]: <https://doc.rust-lang.org/std/mem/fn.size_of.html>

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -638,7 +638,6 @@ impl Default for TestEnumReprU8 {
     }
 }
 
-
 #[derive(MemSize, MemDbg)]
 union TestUnion {
     a: u64,
@@ -699,7 +698,7 @@ fn test_single_field_union_follow_ref() {
         size_of::<usize>() + <TestUnion as MemSize>::mem_size(&test_union, SizeFlags::default()),
     );
 
-    let test_union_deep_mut = TestUnionDeepMut {b: &mut test_union};
+    let test_union_deep_mut = TestUnionDeepMut { b: &mut test_union };
 
     // We check that the shallow size of the test union mut is the
     // size of a reference (i.e. an usize)
@@ -719,7 +718,7 @@ fn test_single_field_union_follow_ref() {
 #[derive(MemSize)]
 union TestUnionMultiField {
     a: u64,
-    _b: (u32, u64)
+    _b: (u32, u64),
 }
 
 impl Default for TestUnionMultiField {

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -639,7 +639,7 @@ impl Default for TestEnumReprU8 {
 }
 
 
-#[derive(MemSize)]
+#[derive(MemSize, MemDbg)]
 union TestUnion {
     a: u64,
 }
@@ -670,12 +670,12 @@ test_size!(
     (TestUnion, 8, 8)
 );
 
-#[derive(MemSize)]
+#[derive(MemSize, MemDbg)]
 union TestUnionDeep<'a> {
     b: &'a TestUnion,
 }
 
-#[derive(MemSize)]
+#[derive(MemSize, MemDbg)]
 union TestUnionDeepMut<'a> {
     b: &'a mut TestUnion,
 }

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -15,7 +15,7 @@ use mem_dbg::*;
 
 #[derive(MemSize, MemDbg)]
 union SingletonUnion<A: Copy> {
-    a: A
+    a: A,
 }
 
 #[allow(dead_code)]

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -13,12 +13,18 @@ use std::sync::atomic::AtomicU64;
 
 use mem_dbg::*;
 
+#[derive(MemSize, MemDbg)]
+union SingletonUnion<A: Copy> {
+    a: A
+}
+
 #[allow(dead_code)]
 #[derive(MemSize, MemDbg)]
 enum TestEnum {
     Unit,
     Unit2(),
     Unit3 {},
+    Union(SingletonUnion<u8>),
     Unnamed(usize, u8),
     Named {
         first: usize,


### PR DESCRIPTION
This pull request adds support for unions with the following limits:

- Single union fields (both mem-size and mem-dbg)
- Multiple field unions without the `FOLLOW_REFS` flag being set (only mem-size)

I am not sure whether we want the second one, as the derive does not raise an error at compile time since the <FOLLOW_REFS> is not known at compile time, but the first one is reasonably fully supported and covers some corner cases I found in other crates (generated by macros).