### PR TITLE
Size of slices exceeds correct value by 8 Bytes

### DIFF
--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -209,10 +209,9 @@ use alloc::vec::Vec;
 impl<T: CopyType + MemSize> MemSizeHelper<False> for [T] {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags) -> usize {
-        self
-                .iter()
-                .map(|x| <T as MemSize>::mem_size(x, flags))
-                .sum::<usize>()
+        self.iter()
+            .map(|x| <T as MemSize>::mem_size(x, flags))
+            .sum::<usize>()
     }
 }
 

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -199,7 +199,7 @@ use alloc::vec::Vec;
 impl<T: CopyType + MemSize> MemSizeHelper<True> for [T] {
     #[inline(always)]
     fn mem_size_impl(&self, _flags: SizeFlags) -> usize {
-        core::mem::size_of::<usize>() + std::mem::size_of_val(self)
+        std::mem::size_of_val(self)
     }
 }
 
@@ -209,8 +209,7 @@ use alloc::vec::Vec;
 impl<T: CopyType + MemSize> MemSizeHelper<False> for [T] {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<usize>()
-            + self
+        self
                 .iter()
                 .map(|x| <T as MemSize>::mem_size(x, flags))
                 .sum::<usize>()

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -143,7 +143,7 @@ impl<T: MemSize> MemSize for Option<T> {
         core::mem::size_of::<Self>()
             + self
                 .as_ref()
-                .map_or(0, |x| x.mem_size(flags) - core::mem::size_of::<T>())
+                .map_or(0, |x| <T as MemSize>::mem_size(x, flags) - core::mem::size_of::<T>())
     }
 }
 
@@ -155,7 +155,7 @@ use alloc::boxed::Box;
 impl<T: ?Sized + MemSize> MemSize for Box<T> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() + self.as_ref().mem_size(flags)
+        core::mem::size_of::<Self>() + <T as MemSize>::mem_size(self.as_ref(), flags)
     }
 }
 
@@ -167,7 +167,7 @@ use std::sync::Arc;
 impl<T: MemSize> MemSize for Arc<T> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.as_ref().mem_size(flags)
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <T as MemSize>::mem_size(self.as_ref(), flags)
     }
 }
 
@@ -208,7 +208,7 @@ use alloc::vec::Vec;
 impl<T: CopyType + MemSize> MemSizeHelper<False> for [T] {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<usize>() + self.iter().map(|x| x.mem_size(flags)).sum::<usize>()
+        core::mem::size_of::<usize>() + self.iter().map(|x| <T as MemSize>::mem_size(x, flags)).sum::<usize>()
     }
 }
 
@@ -241,7 +241,7 @@ impl<T: MemSize, const N: usize> MemSizeHelper<False> for [T; N] {
         core::mem::size_of::<Self>()
             + self
                 .iter()
-                .map(|x| x.mem_size(flags) - core::mem::size_of::<T>())
+                .map(|x| <T as MemSize>::mem_size(x, flags) - core::mem::size_of::<T>())
                 .sum::<usize>()
     }
 }
@@ -284,10 +284,10 @@ impl<T: CopyType + MemSize> MemSizeHelper<False> for Vec<T> {
     fn mem_size_impl(&self, flags: SizeFlags) -> usize {
         if flags.contains(SizeFlags::CAPACITY) {
             core::mem::size_of::<Self>()
-                + self.iter().map(|x| x.mem_size(flags)).sum::<usize>()
+                + self.iter().map(|x| <T as MemSize>::mem_size(x, flags)).sum::<usize>()
                 + (self.capacity() - self.len()) * core::mem::size_of::<T>()
         } else {
-            core::mem::size_of::<Self>() + self.iter().map(|x| x.mem_size(flags)).sum::<usize>()
+            core::mem::size_of::<Self>() + self.iter().map(|x| <T as MemSize>::mem_size(x, flags)).sum::<usize>()
         }
     }
 }
@@ -320,8 +320,8 @@ macro_rules! impl_tuples_muncher {
             #[inline(always)]
             fn mem_size(&self, flags: SizeFlags) -> usize {
                 let mut bytes = core::mem::size_of::<Self>();
-                bytes += self.$idx.mem_size(flags) - core::mem::size_of::<$ty>();
-                $( bytes += self.$nidx.mem_size(flags) - core::mem::size_of::<$nty>(); )*
+                bytes += <$ty as MemSize>::mem_size(&self.$idx, flags) - core::mem::size_of::<$ty>();
+                $( bytes += <$nty as MemSize>::mem_size(&self.$nidx, flags) - core::mem::size_of::<$nty>(); )*
                 bytes
             }
         }
@@ -408,7 +408,7 @@ impl<Idx: CopyType> CopyType for core::ops::Range<Idx> {
 impl<Idx: MemSize> MemSize for core::ops::Range<Idx> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() + self.start.mem_size(flags) + self.end.mem_size(flags)
+        core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size(&self.start, flags) + <Idx as MemSize>::mem_size(&self.end, flags)
             - 2 * core::mem::size_of::<Idx>()
     }
 }
@@ -420,7 +420,7 @@ impl<Idx: CopyType> CopyType for core::ops::RangeFrom<Idx> {
 impl<Idx: MemSize> MemSize for core::ops::RangeFrom<Idx> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() + self.start.mem_size(flags) - core::mem::size_of::<Idx>()
+        core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size(&self.start, flags) - core::mem::size_of::<Idx>()
     }
 }
 
@@ -431,7 +431,7 @@ impl<Idx: CopyType> CopyType for core::ops::RangeInclusive<Idx> {
 impl<Idx: MemSize> MemSize for core::ops::RangeInclusive<Idx> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() + self.start().mem_size(flags) + self.end().mem_size(flags)
+        core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size(&self.start(), flags) + <Idx as MemSize>::mem_size(&self.end(), flags)
             - 2 * core::mem::size_of::<Idx>()
     }
 }
@@ -443,7 +443,7 @@ impl<Idx: CopyType> CopyType for core::ops::RangeTo<Idx> {
 impl<Idx: MemSize> MemSize for core::ops::RangeTo<Idx> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() + self.end.mem_size(flags) - core::mem::size_of::<Idx>()
+        core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size(&self.end, flags) - core::mem::size_of::<Idx>()
     }
 }
 
@@ -454,7 +454,7 @@ impl<Idx: CopyType> CopyType for core::ops::RangeToInclusive<Idx> {
 impl<Idx: MemSize> MemSize for core::ops::RangeToInclusive<Idx> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() + self.end.mem_size(flags) - core::mem::size_of::<Idx>()
+        core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size(&self.end, flags) - core::mem::size_of::<Idx>()
     }
 }
 
@@ -475,7 +475,7 @@ impl<T: CopyType> CopyType for core::cell::RefCell<T> {
 
 impl<T: MemSize> MemSize for core::cell::RefCell<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.borrow().mem_size(flags)
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <T as MemSize>::mem_size(&self.borrow(), flags)
     }
 }
 
@@ -486,7 +486,7 @@ impl<T: CopyType> CopyType for core::cell::Cell<T> {
 impl<T: MemSize> MemSize for core::cell::Cell<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
-            + unsafe { (*self.as_ptr()).mem_size(flags) }
+            + unsafe { <T as MemSize>::mem_size(&*self.as_ptr(), flags) }
     }
 }
 
@@ -496,7 +496,7 @@ impl<T: CopyType> CopyType for core::cell::OnceCell<T> {
 
 impl<T: MemSize> MemSize for core::cell::OnceCell<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.get().mem_size(flags)
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <Option<&T> as MemSize>::mem_size(&self.get(), flags)
     }
 }
 
@@ -507,7 +507,7 @@ impl<T: CopyType> CopyType for core::cell::UnsafeCell<T> {
 impl<T: MemSize> MemSize for core::cell::UnsafeCell<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
-            + unsafe { (*self.get()).mem_size(flags) }
+            + unsafe { <T as MemSize>::mem_size(&*self.get(), flags) }
     }
 }
 
@@ -522,7 +522,7 @@ impl<T: CopyType> CopyType for std::sync::Mutex<T> {
 impl<T: MemSize> MemSize for std::sync::Mutex<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
-            + self.lock().unwrap().mem_size(flags)
+            +  <T as MemSize>::mem_size(&self.lock().unwrap(), flags)
     }
 }
 
@@ -535,7 +535,7 @@ impl<T: CopyType> CopyType for std::sync::RwLock<T> {
 impl<T: MemSize> MemSize for std::sync::RwLock<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
-            + self.read().unwrap().mem_size(flags)
+            + <T as MemSize>::mem_size(&self.read().unwrap(), flags)
     }
 }
 
@@ -548,7 +548,7 @@ impl<T: CopyType> CopyType for std::sync::MutexGuard<'_, T> {
 impl<T: MemSize> MemSize for std::sync::MutexGuard<'_, T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         if flags.contains(SizeFlags::FOLLOW_REFS) {
-            core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.deref().mem_size(flags)
+            core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <T as MemSize>::mem_size(self.deref(), flags)
         } else {
             0
         }
@@ -564,7 +564,7 @@ impl<T: CopyType> CopyType for std::sync::RwLockReadGuard<'_, T> {
 impl<T: MemSize> MemSize for std::sync::RwLockReadGuard<'_, T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         if flags.contains(SizeFlags::FOLLOW_REFS) {
-            core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.deref().mem_size(flags)
+            core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <T as MemSize>::mem_size(self.deref(), flags)
         } else {
             0
         }
@@ -580,7 +580,7 @@ impl<T: CopyType> CopyType for std::sync::RwLockWriteGuard<'_, T> {
 impl<T: MemSize> MemSize for std::sync::RwLockWriteGuard<'_, T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         if flags.contains(SizeFlags::FOLLOW_REFS) {
-            core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.deref().mem_size(flags)
+            core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <T as MemSize>::mem_size(self.deref(), flags)
         } else {
             0
         }
@@ -597,7 +597,7 @@ impl CopyType for std::path::Path {
 #[cfg(feature = "std")]
 impl MemSize for std::path::Path {
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        self.as_os_str().mem_size(flags)
+        <std::ffi::OsStr as MemSize>::mem_size(self.as_os_str(), flags)
     }
 }
 
@@ -610,9 +610,9 @@ impl CopyType for std::path::PathBuf {
 impl MemSize for std::path::PathBuf {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         if flags.contains(SizeFlags::CAPACITY) {
-            core::mem::size_of::<Self>() + self.capacity().mem_size(flags)
+            core::mem::size_of::<Self>() + size_of::<usize>()
         } else {
-            self.as_os_str().mem_size(flags)
+            <std::ffi::OsStr as MemSize>::mem_size(self.as_os_str(), flags)
         }
     }
 }
@@ -643,9 +643,11 @@ impl MemSize for std::ffi::OsString {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::CAPACITY) {
-                self.capacity().mem_size(flags)
+                // Capacity is an usize
+                size_of::<usize>()
             } else {
-                self.len().mem_size(flags)
+                // Len is an usize
+                size_of::<usize>()
             }
     }
 }
@@ -670,7 +672,7 @@ impl<T: MemSize + std::io::Read> CopyType for std::io::BufReader<T> {
 #[cfg(feature = "std")]
 impl<T: MemSize + std::io::Read> MemSize for std::io::BufReader<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.get_ref().mem_size(flags)
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <T as MemSize>::mem_size(self.get_ref(), flags)
     }
 }
 
@@ -682,7 +684,7 @@ impl<T: MemSize + std::io::Write> CopyType for std::io::BufWriter<T> {
 #[cfg(feature = "std")]
 impl<T: MemSize + std::io::Write> MemSize for std::io::BufWriter<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.get_ref().mem_size(flags)
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>() +<T as MemSize>::mem_size(self.get_ref(), flags)
     }
 }
 
@@ -694,7 +696,7 @@ impl<T> CopyType for std::io::Cursor<T> {
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::io::Cursor<T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.get_ref().mem_size(flags)
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>() +<T as MemSize>::mem_size(self.get_ref(), flags)
     }
 }
 
@@ -829,7 +831,7 @@ impl<K: CopyType + MemSize> MemSizeHelper<False> for HashSet<K> {
     fn mem_size_impl(&self, flags: SizeFlags) -> usize {
         fix_set_for_capacity(
             self,
-            self.iter().map(|x| x.mem_size(flags)).sum::<usize>(),
+            self.iter().map(|x| <K as MemSize>::mem_size(x, flags)).sum::<usize>(),
             flags,
         )
     }
@@ -892,7 +894,7 @@ impl<K: CopyType + MemSize, V: CopyType + MemSize> MemSizeHelper2<True, False> f
         fix_map_for_capacity(
             self,
             (std::mem::size_of::<K>()) * self.len()
-                + self.values().map(|v| v.mem_size(flags)).sum::<usize>(),
+                + self.values().map(|v| <V as MemSize>::mem_size(v, flags)).sum::<usize>(),
             flags,
         )
     }
@@ -904,7 +906,7 @@ impl<K: CopyType + MemSize, V: CopyType + MemSize> MemSizeHelper2<False, True> f
     fn mem_size_impl(&self, flags: SizeFlags) -> usize {
         fix_map_for_capacity(
             self,
-            self.keys().map(|k| k.mem_size(flags)).sum::<usize>()
+            self.keys().map(|k| <K as MemSize>::mem_size(k, flags)).sum::<usize>()
                 + (std::mem::size_of::<V>()) * self.len(),
             flags,
         )
@@ -918,7 +920,7 @@ impl<K: CopyType + MemSize, V: CopyType + MemSize> MemSizeHelper2<False, False> 
         fix_map_for_capacity(
             self,
             self.iter()
-                .map(|(k, v)| k.mem_size(flags) + v.mem_size(flags))
+                .map(|(k, v)| <K as MemSize>::mem_size(k, flags) + <V as MemSize>::mem_size(v, flags))
                 .sum::<usize>(),
             flags,
         )
@@ -990,7 +992,7 @@ impl<A: maligned::Alignment, T: MemSize> CopyType for maligned::Aligned<A, T> {
 #[cfg(feature = "maligned")]
 impl<A: maligned::Alignment, T: MemSize> MemSize for maligned::Aligned<A, T> {
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + self.deref().mem_size(flags)
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>() + <T as MemSize>::mem_size(self.deref(), flags)
     }
 }
 

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -445,8 +445,8 @@ impl<Idx: MemSize> MemSize for core::ops::RangeInclusive<Idx> {
     #[inline(always)]
     fn mem_size(&self, flags: SizeFlags) -> usize {
         core::mem::size_of::<Self>()
-            + <Idx as MemSize>::mem_size(&self.start(), flags)
-            + <Idx as MemSize>::mem_size(&self.end(), flags)
+            + <Idx as MemSize>::mem_size(self.start(), flags)
+            + <Idx as MemSize>::mem_size(self.end(), flags)
             - 2 * core::mem::size_of::<Idx>()
     }
 }

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -181,7 +181,7 @@ pub trait MemDbg: MemDbgImpl {
     fn mem_dbg(&self, flags: DbgFlags) -> core::fmt::Result {
         // TODO: fix padding
         self._mem_dbg_depth(
-            self.mem_size(flags.to_size_flags()),
+            <Self as MemSize>::mem_size(self, flags.to_size_flags()),
             usize::MAX,
             std::mem::size_of_val(self),
             flags,
@@ -195,7 +195,7 @@ pub trait MemDbg: MemDbgImpl {
         // TODO: fix padding
         self._mem_dbg_depth_on(
             writer,
-            self.mem_size(flags.to_size_flags()),
+            <Self as MemSize>::mem_size(self, flags.to_size_flags()),
             usize::MAX,
             &mut String::new(),
             Some("⏺"),
@@ -210,7 +210,7 @@ pub trait MemDbg: MemDbgImpl {
     /// levels of nested structures.
     fn mem_dbg_depth(&self, max_depth: usize, flags: DbgFlags) -> core::fmt::Result {
         self._mem_dbg_depth(
-            self.mem_size(flags.to_size_flags()),
+            <Self as MemSize>::mem_size(self, flags.to_size_flags()),
             max_depth,
             std::mem::size_of_val(self),
             flags,
@@ -228,7 +228,7 @@ pub trait MemDbg: MemDbgImpl {
     ) -> core::fmt::Result {
         self._mem_dbg_depth_on(
             writer,
-            self.mem_size(flags.to_size_flags()),
+            <Self as MemSize>::mem_size(self, flags.to_size_flags()),
             max_depth,
             &mut String::new(),
             None,
@@ -316,7 +316,7 @@ pub trait MemDbgImpl: MemSize {
         if prefix.len() > max_depth {
             return Ok(());
         }
-        let real_size = self.mem_size(flags.to_size_flags());
+        let real_size = <Self as MemSize>::mem_size(self, flags.to_size_flags());
         if flags.contains(DbgFlags::HUMANIZE) {
             let (value, uom) = crate::utils::humanize_float(real_size as f64);
             if uom == " B" {

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -390,7 +390,6 @@ pub trait MemDbgImpl: MemSize {
             writer.write_fmt(format_args!(": {:}", core::any::type_name::<Self>()))?;
         }
 
-        //dbg!(padded_size, std::mem::size_of_val(self));
         let padding = padded_size - std::mem::size_of_val(self);
         if padding != 0 {
             writer.write_fmt(format_args!(" [{}B]", padding))?;

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -682,8 +682,10 @@ impl<'a> CustomMutArray<'a> {
 fn test_cloudflare_mut_array() {
     let custom_array: CustomMutArray = CustomMutArray::from_vec(vec![1, 2, 3, 4, 5]);
 
-    let shallow_size =
-        <CustomMutArray as mem_dbg::MemSize>::mem_size(&custom_array, mem_dbg::SizeFlags::default());
+    let shallow_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
+        &custom_array,
+        mem_dbg::SizeFlags::default(),
+    );
 
     // The expected shallow size is 16:
     // - 1 * usize (pointer to the array)
@@ -701,12 +703,16 @@ fn test_cloudflare_mut_array() {
     // - The shallow size (16)
     // - The size of the array (5 * 4 = 20)
 
-    custom_array.mem_dbg(DbgFlags::default() | DbgFlags::FOLLOW_REFS).unwrap();
+    custom_array
+        .mem_dbg(DbgFlags::default() | DbgFlags::FOLLOW_REFS)
+        .unwrap();
 
-    assert_eq!(size_of::<CustomMutArray>() + size_of_val(custom_array.arr), 36);
+    assert_eq!(
+        size_of::<CustomMutArray>() + size_of_val(custom_array.arr),
+        36
+    );
     assert_eq!(deep_size, 36);
 }
-
 
 #[derive(mem_dbg::MemDbg, mem_dbg::MemSize)]
 /// Array representation container

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -688,7 +688,7 @@ fn test_cloudflare_array() {
         mem_dbg::SizeFlags::default(),
     );
 
-    // The expected shallow size is 32:
+    // The expected shallow size is 16:
     // - 1 * usize (pointer to the array)
     // - 1 * usize (len of the array)
 

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -755,12 +755,6 @@ fn test_cloudflare_mut_vector() {
         // - The shallow size (16)
         // - The size of the vector (vector_len.len() * 4 = 20)
 
-        <CustomMutVector as mem_dbg::MemDbg>::mem_dbg(
-            &custom_vector,
-            DbgFlags::default() | DbgFlags::FOLLOW_REFS,
-        )
-        .unwrap();
-
         assert_eq!(
             size_of_val(custom_vector.arr),
             length_of_vector * size_of::<u32>()

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -658,98 +658,133 @@ test_size!(
 );
 
 #[derive(mem_dbg::MemDbg, mem_dbg::MemSize)]
-/// Array representation container
-struct CustomMutArray<'a> {
-    /// Array of items
+/// vector representation container
+struct CustomMutVector<'a> {
+    /// vector of items
     arr: &'a mut [u32],
 }
 
 #[test]
-/// Check that the CustomMutArray used in CloudFlare crates is measured correctly.
-fn test_cloudflare_mut_array() {
+/// Check that the CustomMutVector used in CloudFlare crates is measured correctly.
+fn test_cloudflare_mut_vector() {
     for (case_name, mut vector) in [
         ("Empty vector", vec![]),
         ("Even sized vector", vec![1, 2, 3, 4]),
         ("Odd sized vector", vec![1, 2, 3, 4, 5]),
     ] {
         let length_of_vector = vector.len();
-        let custom_array: CustomMutArray = CustomMutArray {
+        let custom_vector: CustomMutVector = CustomMutVector {
             arr: vector.as_mut_slice(),
         };
 
-        let shallow_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
-            &custom_array,
+        let shallow_size = <CustomMutVector as mem_dbg::MemSize>::mem_size(
+            &custom_vector,
             mem_dbg::SizeFlags::default(),
         );
 
         // The expected shallow size is 16:
-        // - 1 * usize (pointer to the array)
-        // - 1 * usize (len of the array)
+        // - 1 * usize (pointer to the vector)
+        // - 1 * usize (len of the vector)
 
-        assert_eq!(size_of::<CustomMutArray>(), 16);
+        assert_eq!(size_of::<CustomMutVector>(), 16);
         assert_eq!(shallow_size, 16);
 
-        let deep_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
-            &custom_array,
+        let deep_size = <CustomMutVector as mem_dbg::MemSize>::mem_size(
+            &custom_vector,
             mem_dbg::SizeFlags::default() | mem_dbg::SizeFlags::FOLLOW_REFS,
         );
 
         // The expected deep size is 36:
         // - The shallow size (16)
-        // - The size of the array (vector_len.len() * 4 = 20)
+        // - The size of the vector (vector_len.len() * 4 = 20)
 
-        custom_array
-            .mem_dbg(DbgFlags::default() | DbgFlags::FOLLOW_REFS)
-            .unwrap();
+        <CustomMutVector as mem_dbg::MemDbg>::mem_dbg(
+            &custom_vector,
+            DbgFlags::default() | DbgFlags::FOLLOW_REFS,
+        )
+        .unwrap();
 
         assert_eq!(
-            size_of_val(custom_array.arr),
+            size_of_val(custom_vector.arr),
             length_of_vector * size_of::<u32>()
         );
 
         assert_eq!(
             deep_size,
-            size_of::<CustomMutArray>() + size_of_val(custom_array.arr),
+            size_of::<CustomMutVector>() + size_of_val(custom_vector.arr),
             "Failed for case: {}",
             case_name
         );
     }
 }
 
+
 #[derive(mem_dbg::MemDbg, mem_dbg::MemSize)]
-/// Array representation container
-struct CustomArray<'a> {
-    /// Array of items
+/// vector representation container
+struct CustomVector<'a> {
+    /// vector of items
     arr: &'a [u32],
 }
 
 #[test]
-/// Check that the CustomArray used in CloudFlare crates is measured correctly.
-fn test_cloudflare_array() {
-    let array = vec![1, 2, 3, 4, 5];
-    let custom_array: CustomArray = CustomArray {
-        arr: array.as_slice(),
+/// Check that the CustomVector used in CloudFlare crates is measured correctly.
+fn test_cloudflare_vector() {
+    let vector = vec![1, 2, 3, 4, 5];
+    let custom_vector: CustomVector = CustomVector {
+        arr: vector.as_slice(),
     };
 
     let shallow_size =
-        <CustomArray as mem_dbg::MemSize>::mem_size(&custom_array, mem_dbg::SizeFlags::default());
+        <CustomVector as mem_dbg::MemSize>::mem_size(&custom_vector, mem_dbg::SizeFlags::default());
 
     // The expected shallow size is 16:
-    // - 1 * usize (pointer to the array)
-    // - 1 * usize (len of the array)
+    // - 1 * usize (pointer to the vector)
+    // - 1 * usize (len of the vector)
 
-    assert_eq!(size_of::<CustomArray>(), 16);
+    assert_eq!(size_of::<CustomVector>(), 16);
     assert_eq!(shallow_size, 16);
 
-    let deep_size = <CustomArray as mem_dbg::MemSize>::mem_size(
-        &custom_array,
+    let deep_size = <CustomVector as mem_dbg::MemSize>::mem_size(
+        &custom_vector,
         mem_dbg::SizeFlags::default() | mem_dbg::SizeFlags::FOLLOW_REFS,
     );
 
     // The expected deep size is 36:
     // - The shallow size (16)
-    // - The size of the array (5 * 4 = 20)
+    // - The size of the vector (5 * 4 = 20)
 
-    assert_eq!(size_of::<CustomArray>() + size_of_val(custom_array.arr), 36);
+    assert_eq!(size_of::<CustomVector>() + size_of_val(custom_vector.arr), 36);
+    assert_eq!(deep_size, 36);
+}
+
+
+#[test]
+/// Check that the CustomVector used in CloudFlare crates is measured correctly.
+fn test_cloudflare_array() {
+    let vector = [1, 2, 3, 4, 5];
+    let custom_vector: CustomVector = CustomVector {
+        arr: vector.as_slice(),
+    };
+
+    let shallow_size =
+        <CustomVector as mem_dbg::MemSize>::mem_size(&custom_vector, mem_dbg::SizeFlags::default());
+
+    // The expected shallow size is 16:
+    // - 1 * usize (pointer to the vector)
+    // - 1 * usize (len of the vector)
+
+    assert_eq!(size_of::<CustomVector>(), 16);
+    assert_eq!(shallow_size, 16);
+
+    let deep_size = <CustomVector as mem_dbg::MemSize>::mem_size(
+        &custom_vector,
+        mem_dbg::SizeFlags::default() | mem_dbg::SizeFlags::FOLLOW_REFS,
+    );
+
+    // The expected deep size is 36:
+    // - The shallow size (16)
+    // - The size of the vector (5 * 4 = 20)
+
+    assert_eq!(size_of::<CustomVector>() + size_of_val(custom_vector.arr), 36);
     assert_eq!(deep_size, 36);
 }

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -657,7 +657,6 @@ test_size!(
     (TestEnumReprU8, 40, 40)
 );
 
-
 #[derive(mem_dbg::MemDbg, mem_dbg::MemSize)]
 /// Array representation container
 struct CustomArray<'a> {
@@ -683,10 +682,8 @@ impl<'a> CustomArray<'a> {
 fn test_cloudflare_array() {
     let custom_array: CustomArray = CustomArray::from_vec(vec![1, 2, 3, 4, 5]);
 
-    let shallow_size = <CustomArray as mem_dbg::MemSize>::mem_size(
-        &custom_array,
-        mem_dbg::SizeFlags::default(),
-    );
+    let shallow_size =
+        <CustomArray as mem_dbg::MemSize>::mem_size(&custom_array, mem_dbg::SizeFlags::default());
 
     // The expected shallow size is 16:
     // - 1 * usize (pointer to the array)

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -718,7 +718,6 @@ fn test_cloudflare_mut_vector() {
     }
 }
 
-
 #[derive(mem_dbg::MemDbg, mem_dbg::MemSize)]
 /// vector representation container
 struct CustomVector<'a> {
@@ -753,10 +752,12 @@ fn test_cloudflare_vector() {
     // - The shallow size (16)
     // - The size of the vector (5 * 4 = 20)
 
-    assert_eq!(size_of::<CustomVector>() + size_of_val(custom_vector.arr), 36);
+    assert_eq!(
+        size_of::<CustomVector>() + size_of_val(custom_vector.arr),
+        36
+    );
     assert_eq!(deep_size, 36);
 }
-
 
 #[test]
 /// Check that the CustomVector used in CloudFlare crates is measured correctly.
@@ -785,6 +786,9 @@ fn test_cloudflare_array() {
     // - The shallow size (16)
     // - The size of the vector (5 * 4 = 20)
 
-    assert_eq!(size_of::<CustomVector>() + size_of_val(custom_vector.arr), 36);
+    assert_eq!(
+        size_of::<CustomVector>() + size_of_val(custom_vector.arr),
+        36
+    );
     assert_eq!(deep_size, 36);
 }

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -689,6 +689,7 @@ fn test_cloudflare_array() {
     // - 1 * usize (pointer to the array)
     // - 1 * usize (len of the array)
 
+    assert_eq!(size_of::<CustomArray>(), 16);
     assert_eq!(shallow_size, 16);
 
     let deep_size = <CustomArray as mem_dbg::MemSize>::mem_size(
@@ -696,9 +697,10 @@ fn test_cloudflare_array() {
         mem_dbg::SizeFlags::default() | mem_dbg::SizeFlags::FOLLOW_REFS,
     );
 
-    // The expected deep size is:
+    // The expected deep size is 36:
     // - The shallow size (16)
     // - The size of the array (5 * 4 = 20)
 
+    assert_eq!(size_of::<CustomArray>() + size_of_val(custom_array.arr), 36);
     assert_eq!(deep_size, shallow_size + 20);
 }

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -359,6 +359,7 @@ fn test_vec_slice_i64() {
 
     // A mutable slice should have the same size as a non mutable one
     let non_mutable_slice = data.as_slice();
+    let size_of_non_mutable_slice = size_of_val(non_mutable_slice);
     let non_mutable_slice_shallow_size =
         <&[i64] as MemSize>::mem_size(&non_mutable_slice, SizeFlags::default());
     let non_mutable_slice_deep_size = <&[i64] as MemSize>::mem_size(
@@ -366,6 +367,7 @@ fn test_vec_slice_i64() {
         SizeFlags::default() | SizeFlags::FOLLOW_REFS,
     );
     let mutable_slice = data.as_mut_slice();
+    let size_of_mutable_slice = size_of_val(mutable_slice);
     let mutable_slice_shallow_size =
         <&mut [i64] as MemSize>::mem_size(&mutable_slice, SizeFlags::default());
     let mutable_slice_deep_size = <&mut [i64] as MemSize>::mem_size(
@@ -382,6 +384,20 @@ fn test_vec_slice_i64() {
         mutable_slice_deep_size, non_mutable_slice_deep_size,
         "Expected mutable slice deep size to be identical to non mutable slice deep size"
     );
+
+    assert_eq!(non_mutable_slice_shallow_size, size_of::<&[i64]>());
+
+    assert_eq!(mutable_slice_shallow_size, size_of::<&mut [i64]>());
+
+    assert_eq!(
+        non_mutable_slice_deep_size,
+        size_of::<&[i64]>() + size_of_non_mutable_slice
+    );
+
+    assert_eq!(
+        mutable_slice_deep_size,
+        size_of::<&mut [i64]>() + size_of_mutable_slice
+    );
 }
 
 #[test]
@@ -390,6 +406,7 @@ fn test_vec_slice_i32() {
 
     // A mutable slice should have the same size as a non mutable one
     let non_mutable_slice = data.as_slice();
+    let size_of_non_mutable_slice = size_of_val(non_mutable_slice);
     let non_mutable_slice_shallow_size =
         <&[i32] as MemSize>::mem_size(&non_mutable_slice, SizeFlags::default());
     let non_mutable_slice_deep_size = <&[i32] as MemSize>::mem_size(
@@ -397,6 +414,7 @@ fn test_vec_slice_i32() {
         SizeFlags::default() | SizeFlags::FOLLOW_REFS,
     );
     let mutable_slice = data.as_mut_slice();
+    let size_of_mutable_slice = size_of_val(mutable_slice);
     let mutable_slice_shallow_size =
         <&mut [i32] as MemSize>::mem_size(&mutable_slice, SizeFlags::default());
     let mutable_slice_deep_size = <&mut [i32] as MemSize>::mem_size(
@@ -413,6 +431,20 @@ fn test_vec_slice_i32() {
         mutable_slice_deep_size, non_mutable_slice_deep_size,
         "Expected mutable slice deep size to be identical to non mutable slice deep size"
     );
+
+    assert_eq!(non_mutable_slice_shallow_size, size_of::<&[i64]>());
+
+    assert_eq!(mutable_slice_shallow_size, size_of::<&mut [i64]>());
+
+    assert_eq!(
+        non_mutable_slice_deep_size,
+        size_of::<&[i64]>() + size_of_non_mutable_slice
+    );
+
+    assert_eq!(
+        mutable_slice_deep_size,
+        size_of::<&mut [i64]>() + size_of_mutable_slice
+    );
 }
 
 #[test]
@@ -421,6 +453,7 @@ fn test_array_slice_i64() {
 
     // A mutable slice should have the same size as a non mutable one
     let non_mutable_slice = data.as_slice();
+    let size_of_non_mutable_slice = size_of_val(non_mutable_slice);
     let non_mutable_slice_shallow_size =
         <&[i64] as MemSize>::mem_size(&non_mutable_slice, SizeFlags::default());
     let non_mutable_slice_deep_size = <&[i64] as MemSize>::mem_size(
@@ -428,6 +461,7 @@ fn test_array_slice_i64() {
         SizeFlags::default() | SizeFlags::FOLLOW_REFS,
     );
     let mutable_slice = data.as_mut_slice();
+    let size_of_mutable_slice = size_of_val(mutable_slice);
     let mutable_slice_shallow_size =
         <&mut [i64] as MemSize>::mem_size(&mutable_slice, SizeFlags::default());
     let mutable_slice_deep_size = <&mut [i64] as MemSize>::mem_size(
@@ -443,6 +477,16 @@ fn test_array_slice_i64() {
     assert_eq!(
         mutable_slice_deep_size, non_mutable_slice_deep_size,
         "Expected mutable slice deep size to be identical to non mutable slice deep size"
+    );
+
+    assert_eq!(
+        non_mutable_slice_deep_size,
+        size_of::<&[i64]>() + size_of_non_mutable_slice
+    );
+
+    assert_eq!(
+        mutable_slice_deep_size,
+        size_of::<&mut [i64]>() + size_of_mutable_slice
     );
 }
 
@@ -480,6 +524,7 @@ fn test_array_slice_i32() {
 
     // A mutable slice should have the same size as a non mutable one
     let non_mutable_slice = data.as_slice();
+    let size_of_non_mutable_slice = size_of_val(non_mutable_slice);
     let non_mutable_slice_shallow_size =
         <&[i32] as MemSize>::mem_size(&non_mutable_slice, SizeFlags::default());
     let non_mutable_slice_deep_size = <&[i32] as MemSize>::mem_size(
@@ -487,6 +532,7 @@ fn test_array_slice_i32() {
         SizeFlags::default() | SizeFlags::FOLLOW_REFS,
     );
     let mutable_slice = data.as_mut_slice();
+    let size_of_mutable_slice = size_of_val(mutable_slice);
     let mutable_slice_shallow_size =
         <&mut [i32] as MemSize>::mem_size(&mutable_slice, SizeFlags::default());
     let mutable_slice_deep_size = <&mut [i32] as MemSize>::mem_size(
@@ -502,6 +548,16 @@ fn test_array_slice_i32() {
     assert_eq!(
         mutable_slice_deep_size, non_mutable_slice_deep_size,
         "Expected mutable slice deep size to be identical to non mutable slice deep size"
+    );
+
+    assert_eq!(
+        non_mutable_slice_deep_size,
+        size_of::<&[i64]>() + size_of_non_mutable_slice
+    );
+
+    assert_eq!(
+        mutable_slice_deep_size,
+        size_of::<&mut [i64]>() + size_of_mutable_slice
     );
 }
 

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -702,5 +702,5 @@ fn test_cloudflare_array() {
     // - The size of the array (5 * 4 = 20)
 
     assert_eq!(size_of::<CustomArray>() + size_of_val(custom_array.arr), 36);
-    assert_eq!(deep_size, shallow_size + 20);
+    assert_eq!(deep_size, 36);
 }

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -672,8 +672,9 @@ fn test_cloudflare_mut_array() {
         ("Even sized vector", vec![1, 2, 3, 4]),
         ("Odd sized vector", vec![1, 2, 3, 4, 5]),
     ] {
+        let length_of_vector = vector.len();
         let custom_array: CustomMutArray = CustomMutArray {
-            arr: vector.as_mut_slice()
+            arr: vector.as_mut_slice(),
         };
 
         let shallow_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
@@ -702,6 +703,11 @@ fn test_cloudflare_mut_array() {
             .unwrap();
 
         assert_eq!(
+            size_of_val(custom_array.arr),
+            length_of_vector * size_of::<u32>()
+        );
+
+        assert_eq!(
             deep_size,
             size_of::<CustomMutArray>() + size_of_val(custom_array.arr),
             "Failed for case: {}",
@@ -722,7 +728,7 @@ struct CustomArray<'a> {
 fn test_cloudflare_array() {
     let array = vec![1, 2, 3, 4, 5];
     let custom_array: CustomArray = CustomArray {
-        arr: array.as_slice()
+        arr: array.as_slice(),
     };
 
     let shallow_size =

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -664,54 +664,50 @@ struct CustomMutArray<'a> {
     arr: &'a mut [u32],
 }
 
-impl<'a> CustomMutArray<'a> {
-    /// Create new instance of `CustomMutArray` representation from vector
-    #[inline]
-    fn from_vec(mut arr: Vec<u32>) -> Self {
-        let cap = arr.len();
-        let ptr = arr.as_mut_ptr();
-        std::mem::forget(arr);
-        // SAFETY: valid pointer from vector being used to create slice reference
-        let arr = unsafe { core::slice::from_raw_parts_mut(ptr, cap) };
-        Self { arr }
-    }
-}
-
 #[test]
 /// Check that the CustomMutArray used in CloudFlare crates is measured correctly.
 fn test_cloudflare_mut_array() {
-    let custom_array: CustomMutArray = CustomMutArray::from_vec(vec![1, 2, 3, 4, 5]);
+    for (case_name, mut vector) in [
+        ("Empty vector", vec![]),
+        ("Even sized vector", vec![1, 2, 3, 4]),
+        ("Odd sized vector", vec![1, 2, 3, 4, 5]),
+    ] {
+        let custom_array: CustomMutArray = CustomMutArray {
+            arr: vector.as_mut_slice()
+        };
 
-    let shallow_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
-        &custom_array,
-        mem_dbg::SizeFlags::default(),
-    );
+        let shallow_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
+            &custom_array,
+            mem_dbg::SizeFlags::default(),
+        );
 
-    // The expected shallow size is 16:
-    // - 1 * usize (pointer to the array)
-    // - 1 * usize (len of the array)
+        // The expected shallow size is 16:
+        // - 1 * usize (pointer to the array)
+        // - 1 * usize (len of the array)
 
-    assert_eq!(size_of::<CustomMutArray>(), 16);
-    assert_eq!(shallow_size, 16);
+        assert_eq!(size_of::<CustomMutArray>(), 16);
+        assert_eq!(shallow_size, 16);
 
-    let deep_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
-        &custom_array,
-        mem_dbg::SizeFlags::default() | mem_dbg::SizeFlags::FOLLOW_REFS,
-    );
+        let deep_size = <CustomMutArray as mem_dbg::MemSize>::mem_size(
+            &custom_array,
+            mem_dbg::SizeFlags::default() | mem_dbg::SizeFlags::FOLLOW_REFS,
+        );
 
-    // The expected deep size is 36:
-    // - The shallow size (16)
-    // - The size of the array (5 * 4 = 20)
+        // The expected deep size is 36:
+        // - The shallow size (16)
+        // - The size of the array (vector_len.len() * 4 = 20)
 
-    custom_array
-        .mem_dbg(DbgFlags::default() | DbgFlags::FOLLOW_REFS)
-        .unwrap();
+        custom_array
+            .mem_dbg(DbgFlags::default() | DbgFlags::FOLLOW_REFS)
+            .unwrap();
 
-    assert_eq!(
-        size_of::<CustomMutArray>() + size_of_val(custom_array.arr),
-        36
-    );
-    assert_eq!(deep_size, 36);
+        assert_eq!(
+            deep_size,
+            size_of::<CustomMutArray>() + size_of_val(custom_array.arr),
+            "Failed for case: {}",
+            case_name
+        );
+    }
 }
 
 #[derive(mem_dbg::MemDbg, mem_dbg::MemSize)]
@@ -721,23 +717,13 @@ struct CustomArray<'a> {
     arr: &'a [u32],
 }
 
-impl<'a> CustomArray<'a> {
-    /// Create new instance of `CustomArray` representation from vector
-    #[inline]
-    fn from_vec(arr: Vec<u32>) -> Self {
-        let cap = arr.len();
-        let ptr = arr.as_ptr();
-        std::mem::forget(arr);
-        // SAFETY: valid pointer from vector being used to create slice reference
-        let arr = unsafe { core::slice::from_raw_parts(ptr, cap) };
-        Self { arr }
-    }
-}
-
 #[test]
 /// Check that the CustomArray used in CloudFlare crates is measured correctly.
 fn test_cloudflare_array() {
-    let custom_array: CustomArray = CustomArray::from_vec(vec![1, 2, 3, 4, 5]);
+    let array = vec![1, 2, 3, 4, 5];
+    let custom_array: CustomArray = CustomArray {
+        arr: array.as_slice()
+    };
 
     let shallow_size =
         <CustomArray as mem_dbg::MemSize>::mem_size(&custom_array, mem_dbg::SizeFlags::default());

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -701,6 +701,8 @@ fn test_cloudflare_mut_array() {
     // - The shallow size (16)
     // - The size of the array (5 * 4 = 20)
 
+    custom_array.mem_dbg(DbgFlags::default() | DbgFlags::FOLLOW_REFS).unwrap();
+
     assert_eq!(size_of::<CustomMutArray>() + size_of_val(custom_array.arr), 36);
     assert_eq!(deep_size, 36);
 }


### PR DESCRIPTION
While we managed to fix the early `&mut T` bug, it wasn't the one I encountered in the other crates. This pull request adds a test with the case encountered in the other crate, which is currently failing. @vigna when you have time, please do check whether my expected deep size of the `CustomArray` is correct.