### PR TITLE
Now library actually compiled in no-std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,10 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
+      - name: Run no default features tests
+        run: cargo test --verbose --no-default-features
+      - name: Run tests with alloc feature
+        run: cargo test --verbose --no-default-features --features alloc
       - name: Run examples
         working-directory: ./mem_dbg
         run: for example in examples/*.rs ; do cargo run --example "$(basename "${example%.rs}")" ; done

--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -22,7 +22,7 @@ maligned = {version="0.2.1", optional = true}
 paste = "1.0.15"
 
 [features]
-default = ["std", "derive"]
+default = ["derive", "std"]
 std = ["alloc"]
 derive = ["mem_dbg-derive"]
 offset_of_enum = []

--- a/mem_dbg/examples/bench_hash_map/Cargo.toml
+++ b/mem_dbg/examples/bench_hash_map/Cargo.toml
@@ -11,3 +11,6 @@ deepsize = "0.2.0"
 get-size = "0.1.4"
 size-of = "0.1.5"
 
+[features]
+default = ["std"]
+std = ["mem_dbg/std"]

--- a/mem_dbg/examples/bench_hash_map/src/main.rs
+++ b/mem_dbg/examples/bench_hash_map/src/main.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 #[global_allocator]
 static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::MAX);
 
+#[cfg(feature = "std")]
 fn main() {
     const N: usize = 100_000_000;
     let mut m = HashMap::with_capacity(N);
@@ -34,4 +35,9 @@ fn main() {
     let start = Instant::now();
     let size = m.mem_size(SizeFlags::default());
     println!("mem_size:     {} {:?} ns", size, start.elapsed().as_nanos());
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {
+    println!("This example requires the 'std' feature.");
 }

--- a/mem_dbg/examples/example.rs
+++ b/mem_dbg/examples/example.rs
@@ -8,8 +8,6 @@
 #![cfg_attr(feature = "offset_of_enum", feature(offset_of_enum, offset_of_nested))]
 #![allow(dead_code)]
 
-use std::collections::HashSet;
-
 use mem_dbg::*;
 
 #[derive(Clone, Copy, MemSize, MemDbg)]
@@ -29,11 +27,12 @@ struct TestMarker;
 struct TestTuple(usize, u8);
 
 #[derive(MemSize, MemDbg)]
+#[cfg(feature = "std")]
 struct Struct<A, B> {
     a: A,
     b: B,
     test: isize,
-    h: HashSet<usize>,
+    h: std::collections::HashSet<usize>,
 }
 
 #[derive(MemSize, MemDbg)]
@@ -43,10 +42,11 @@ struct Data<A> {
     c: (u8, String),
 }
 
+#[cfg(feature = "std")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut b = Vec::with_capacity(100);
     b.extend(0..10);
-    let mut h = HashSet::with_capacity(100);
+    let mut h = std::collections::HashSet::with_capacity(100);
     h.extend(0..10);
 
     let s = Struct {
@@ -119,7 +119,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         a: 0_u8,
         b: 0_u8,
         test: 1,
-        h: HashSet::new(),
+        h: std::collections::HashSet::new(),
     };
 
     println!();
@@ -135,4 +135,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     s.mem_dbg(DbgFlags::RUST_LAYOUT)?;
 
     Ok(())
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {
+    println!("This example requires the 'std' feature.");
 }

--- a/mem_dbg/examples/readme.rs
+++ b/mem_dbg/examples/readme.rs
@@ -8,8 +8,10 @@
 #![cfg_attr(feature = "offset_of_enum", feature(offset_of_enum, offset_of_nested))]
 #![allow(dead_code)]
 
+#[cfg(feature = "std")]
 use mem_dbg::*;
 
+#[cfg(feature = "std")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use mem_dbg::*;
 
@@ -73,4 +75,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         s.mem_dbg(DbgFlags::empty() | DbgFlags::RUST_LAYOUT)?;
     }
     Ok(())
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {
+    println!("This example requires the 'std' feature.");
 }

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -12,6 +12,9 @@
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::string::String;
+
 #[cfg(feature = "derive")]
 pub use mem_dbg_derive::{MemDbg, MemSize};
 
@@ -176,14 +179,14 @@ impl Default for DbgFlags {
 pub trait MemDbg: MemDbgImpl {
     /// Writes to stdout debug infos about the structure memory usage, expanding
     /// all levels of nested structures.
-    #[cfg(feature = "std")]
     #[inline(always)]
+    #[cfg(feature = "std")]
     fn mem_dbg(&self, flags: DbgFlags) -> core::fmt::Result {
         // TODO: fix padding
         self._mem_dbg_depth(
             self.mem_size(flags.to_size_flags()),
             usize::MAX,
-            std::mem::size_of_val(self),
+            core::mem::size_of_val(self),
             flags,
         )
     }
@@ -200,11 +203,12 @@ pub trait MemDbg: MemDbgImpl {
             &mut String::new(),
             Some("⏺"),
             true,
-            std::mem::size_of_val(self),
+            core::mem::size_of_val(self),
             flags,
         )
     }
 
+    #[cfg(feature = "std")]
     /// Writes to stdout debug infos about the structure memory usage as
     /// [`mem_dbg`](MemDbg::mem_dbg), but expanding only up to `max_depth`
     /// levels of nested structures.
@@ -212,7 +216,7 @@ pub trait MemDbg: MemDbgImpl {
         self._mem_dbg_depth(
             self.mem_size(flags.to_size_flags()),
             max_depth,
-            std::mem::size_of_val(self),
+            core::mem::size_of_val(self),
             flags,
         )
     }
@@ -233,7 +237,7 @@ pub trait MemDbg: MemDbgImpl {
             &mut String::new(),
             None,
             false,
-            std::mem::size_of_val(self),
+            core::mem::size_of_val(self),
             flags,
         )
     }
@@ -323,7 +327,7 @@ pub trait MemDbgImpl: MemSize {
                 writer.write_fmt(format_args!("{:>5}  B ", real_size))?;
             } else {
                 let mut precision = 4;
-                let a = value.abs();
+                let a = if value < 0.0 { -value } else { value };
                 if a >= 100.0 {
                     precision = 1;
                 } else if a >= 10.0 {
@@ -390,8 +394,8 @@ pub trait MemDbgImpl: MemSize {
             writer.write_fmt(format_args!(": {:}", core::any::type_name::<Self>()))?;
         }
 
-        //dbg!(padded_size, std::mem::size_of_val(self));
-        let padding = padded_size - std::mem::size_of_val(self);
+        //dbg!(padded_size, core::mem::size_of_val(self));
+        let padding = padded_size - core::mem::size_of_val(self);
         if padding != 0 {
             writer.write_fmt(format_args!(" [{}B]", padding))?;
         }

--- a/mem_dbg/src/utils.rs
+++ b/mem_dbg/src/utils.rs
@@ -18,13 +18,15 @@ pub fn humanize_float(mut x: f64) -> (f64, &'static str) {
         return (0.0, UOM[uom_idx]);
     }
 
-    if x.abs() > 1.0 {
-        while x.abs() > 1000.0 && uom_idx < UOM.len() - 1 {
+    let abs_x = if x < 0.0 { -x } else { x };
+
+    if abs_x > 1.0 {
+        while abs_x > 1000.0 && uom_idx < UOM.len() - 1 {
             uom_idx += 1;
             x /= 1000.0;
         }
     } else {
-        while x.abs() < 0.001 && uom_idx > 0 {
+        while abs_x < 0.001 && uom_idx > 0 {
             uom_idx -= 1;
             x *= 1000.0;
         }

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -306,6 +306,7 @@ fn test_unit() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_phantom() {
     struct Dummy();
     #[derive(MemSize, MemDbg)]
@@ -317,18 +318,21 @@ fn test_phantom() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_vec_strings() {
     let data = vec![String::new(), String::new()];
     data.mem_dbg(DbgFlags::default()).unwrap();
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_array_u8() {
     let data = [0_u8; 10];
     data.mem_dbg(DbgFlags::default()).unwrap();
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_array() {
     #[derive(MemSize, MemDbg, Clone, Copy)]
     struct Dummy;
@@ -337,6 +341,7 @@ fn test_array() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_indirect_call() {
     #[derive(MemSize, MemDbg)]
     struct Dummy<T>(Vec<T>);


### PR DESCRIPTION
I noticed that while the library has an "std" feature that can be turned off, it does not compile without std and alloc.

Now it compiles and provides a reduced set of features (e.g. MemSize).

I have also added tests in the CI to verify that it builds and runs the tests successfully also in no-std mode.