### PR TITLE
Various improvements

### DIFF
--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -12,11 +12,11 @@ authors = ["Tommaso Fontana <tommaso.fontana.96@gmail.com>", "Sebastiano Vigna <
 [dependencies]
 mem_dbg-derive =  { version = "=0.1.6", optional = true }
 #mem_dbg-derive =  { path = "../mem_dbg-derive", optional = true }
-mmap-rs = {version="0.6.0", optional=true}
+mmap-rs = {version="0.6.0", optional=true }
 half = { version = "2.0.4", optional = true }
 bitflags = "2.4.1"
-rand = {version = "0.8.5", optional = true, features = ["small_rng"]}
-maligned = {version="0.2.1", optional = true}
+rand = {version = "0.8.5", optional = true, features = ["small_rng"] }
+maligned = {version="0.2.1", optional = true }
 
 [dev-dependencies]
 paste = "1.0.15"

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -136,7 +136,7 @@ bitflags::bitflags! {
         const TYPE_NAME = 1 << 3;
         /// Display capacity instead of size. See [`SizeFlags::CAPACITY`].
         const CAPACITY = 1 << 4;
-        /// Add an underscore every 3 digits.
+        /// Add an underscore every 3 digits, when `HUMANIZE` is not set.
         const SEPARATOR = 1 << 5;
         /// Print fields in memory order (i.e., using the layout chosen by the
         /// compiler), rather than in declaration order.

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -174,7 +174,7 @@ impl Default for DbgFlags {
 /// type implement [`MemDbg`]. Note that you will also need to derive
 /// [`MemSize`].
 pub trait MemDbg: MemDbgImpl {
-    /// Writes to stdout debug infos about the structure memory usage, expanding
+    /// Writes to stderr debug infos about the structure memory usage, expanding
     /// all levels of nested structures.
     #[cfg(feature = "std")]
     #[inline(always)]
@@ -205,7 +205,7 @@ pub trait MemDbg: MemDbgImpl {
         )
     }
 
-    /// Writes to stdout debug infos about the structure memory usage as
+    /// Writes to stderr debug infos about the structure memory usage as
     /// [`mem_dbg`](MemDbg::mem_dbg), but expanding only up to `max_depth`
     /// levels of nested structures.
     fn mem_dbg_depth(&self, max_depth: usize, flags: DbgFlags) -> core::fmt::Result {
@@ -276,7 +276,7 @@ pub trait MemDbgImpl: MemSize {
         padded_size: usize,
         flags: DbgFlags,
     ) -> core::fmt::Result {
-        struct Wrapper(std::io::Stdout);
+        struct Wrapper(std::io::Stderr);
         impl core::fmt::Write for Wrapper {
             #[inline(always)]
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
@@ -289,7 +289,7 @@ pub trait MemDbgImpl: MemSize {
             }
         }
         self._mem_dbg_depth_on(
-            &mut Wrapper(std::io::stdout()),
+            &mut Wrapper(std::io::stderr()),
             total_size,
             max_depth,
             &mut String::new(),

--- a/mem_dbg/src/utils.rs
+++ b/mem_dbg/src/utils.rs
@@ -33,6 +33,31 @@ pub fn humanize_float(mut x: f64) -> (f64, &'static str) {
     (x, UOM[uom_idx])
 }
 
+pub fn color(x: usize) -> &'static str {
+    const KB: usize = 1024;
+    const MB: usize = KB * KB;
+    const GB: usize = MB * KB;
+    match x {
+        // white
+        ..KB => reset_color(),
+        // green
+        ..MB => "\x1B[32m",
+        // yellow
+        ..GB => "\x1B[33m",
+        // red
+        _ => "\x1B[31m",
+    }
+}
+
+pub fn type_color() -> &'static str {
+    // custom grey
+    "\x1B[38;2;128;128;128m"
+}
+
+pub fn reset_color() -> &'static str {
+    "\x1B[0m"
+}
+
 /// Returns the number of digits of a number.
 ///
 /// ```


### PR DESCRIPTION
1. Write to `stderr`
2. Small fixes
3. `COLOR` flag for colorized output. fixes https://github.com/vigna/sux-rs/issues/56.

For the coloring, this currently uses linux color codes. We could make it cross-platform by adding a dependency.

Open question: How to skip showing small fields. Could be an integer parameter, or a `SKIP_SMALL` flag that skips fields of size at most `8` or `16` bytes or so.