### PR TITLE
CopyType for Boxes

### DIFF
--- a/mem_dbg/examples/example.rs
+++ b/mem_dbg/examples/example.rs
@@ -139,26 +139,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     s.mem_dbg(DbgFlags::RUST_LAYOUT)?;
 
-    let s = Data2 {
-        array_of_boxed_slices: [
-            Box::new([0; 1024]),
-            Box::new([1; 2048]),
-            Box::new([2; 4096]),
-            Box::new([3; 8192]),
-        ],
-    };
-
-    println!();
-
-    println!("DbgFlags::empty()");
-    println!();
-    s.mem_dbg(DbgFlags::empty())?;
-
-    println!();
-
-    println!("DbgFlags::RUST_LAYOUT");
-    println!();
-    s.mem_dbg(DbgFlags::RUST_LAYOUT)?;
-
     Ok(())
 }

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -146,13 +146,13 @@ impl<T: MemSize> MemSize for Option<T> {
 }
 
 // Box
-
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
 impl<T: ?Sized> CopyType for Box<T> {
     type Copy = False;
 }
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 impl<T: ?Sized + MemSize> MemSize for Box<T> {
     #[inline(always)]

--- a/mem_dbg/tests/test_mem_size.rs
+++ b/mem_dbg/tests/test_mem_size.rs
@@ -396,6 +396,41 @@ fn test_indirect_call() {
 }
 
 #[test]
+fn test_array_of_boxed_slices() {
+    #[derive(MemSize, MemDbg)]
+    struct Data {
+        array_of_boxed_slices: [Box<[usize]>; 4],
+    }
+
+    let data = Data {
+        array_of_boxed_slices: [
+            vec![1_usize, 2, 3].into_boxed_slice(),
+            vec![4_usize, 5, 6, 7].into_boxed_slice(),
+            vec![8_usize, 9].into_boxed_slice(),
+            Box::new([2; 4096]),
+        ],
+    };
+
+    assert_eq!(
+        data.mem_size(SizeFlags::default()),
+        core::mem::size_of::<[Box<[usize]>; 4]>()
+            + 3 * core::mem::size_of::<usize>()
+            + 4 * core::mem::size_of::<usize>()
+            + 2 * core::mem::size_of::<usize>()
+            + 4096 * core::mem::size_of::<usize>()
+    );
+
+    assert_eq!(
+        data.mem_size(SizeFlags::CAPACITY),
+        core::mem::size_of::<[Box<[usize]>; 4]>()
+            + 3 * core::mem::size_of::<usize>()
+            + 4 * core::mem::size_of::<usize>()
+            + 2 * core::mem::size_of::<usize>()
+            + 4096 * core::mem::size_of::<usize>()
+    );
+}
+
+#[test]
 fn test_vec_slice_i64() {
     let mut data: Vec<i64> = vec![1, 2, 3, 4, 5];
 


### PR DESCRIPTION
I'm trying to adopt `mem_dbg` in a project I'm working on. Unfortunately, turns out as of now it's not possible to derive the traits MemSize and MemDbg for structures of this kind:
```rust
#[derive(MemSize, MemDbg)]
struct Data {
    array_of_boxed_slices: [Box<[usize]>; 4],
}
```
This contribution makes it possible by implementing `CopyType` for `Box<T>`. 

