### PR TITLE
Removed miri

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,14 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install nightly toolchain + miri
-        run: rustup toolchain install nightly && rustup default nightly && rustup component add miri
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly && rustup default nightly
       - name: Build with all features
         run: cargo build --all-features
       - name: Run tests with all features (including offset_of_enum)
         run: cargo test --all-features
-      - name: Run miri with all features except half (because of ASM code)
-        run: MIRIFLAGS=-Zmiri-disable-isolation cargo miri test --features std,derive,rand,maligned,offset_of_enum
         
   coverage:
     needs: [build-stable, build-nightly]


### PR DESCRIPTION
At the time of writing, miri is taking certainly more than one hour to complete in the CI. We do not know how much time it will actually take to complete. I suggest we remove it from the CI, and simply run it locally as needed.

See: https://github.com/zommiommy/mem_dbg-rs/actions/runs/21063848830

Luca