### PR TITLE
Pr2 core wrapper impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   followed: their referents are neither dereferenced nor counted, and the
   `Weak` impls do not bound the target type.
 
+- Added `MemSize`/`MemDbg` implementations for `core::cmp::Reverse`,
+  `core::ops::Bound`, `core::task::Poll`, and `core::ops::ControlFlow`.
+  These wrappers only visit the payload variant that is actually present.
+
 
 ## [0.4.1] - 2026-03-25
 

--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -25,6 +25,7 @@ maligned = { version = "0.2.1", optional = true }
 hashbrown = "0.16"
 
 [dev-dependencies]
+anyhow = "1"
 comfy-table = "=7.2.1"
 paste = "1.0.15"
 cap = "0.1.2"

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -167,6 +167,87 @@ impl<T: MemDbgImpl> MemDbgImpl for Option<T> {}
 
 impl<T: MemDbgImpl, E: MemDbgImpl> MemDbgImpl for Result<T, E> {}
 
+// Sum/newtype wrappers delegate debug traversal to the active payload only.
+
+impl<B: MemDbgImpl, C: MemDbgImpl> MemDbgImpl for core::ops::ControlFlow<B, C> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        match self {
+            core::ops::ControlFlow::Break(b) => b._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            ),
+            core::ops::ControlFlow::Continue(c) => c._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            ),
+        }
+    }
+}
+
+impl<T: MemDbgImpl> MemDbgImpl for core::task::Poll<T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        match self {
+            core::task::Poll::Ready(t) => t._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            ),
+            core::task::Poll::Pending => Ok(()),
+        }
+    }
+}
+
+impl<T: MemDbgImpl> MemDbgImpl for core::ops::Bound<T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        match self {
+            core::ops::Bound::Included(t) | core::ops::Bound::Excluded(t) => t._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            ),
+            core::ops::Bound::Unbounded => Ok(()),
+        }
+    }
+}
+
+impl<T: MemDbgImpl> MemDbgImpl for core::cmp::Reverse<T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        self.0._mem_dbg_rec_on(
+            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        )
+    }
+}
+
 // Box
 
 impl<T: ?Sized + MemDbgImpl> MemDbgImpl for Box<T> {

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -176,6 +176,69 @@ impl<T: MemSize, E: MemSize> MemSize for Result<T, E> {
     }
 }
 
+// Sum/newtype wrappers only recurse into the active payload.
+
+impl<B: FlatType, C: FlatType> FlatType for core::ops::ControlFlow<B, C> {
+    type Flat = <B::Flat as Boolean>::And<C::Flat>;
+}
+
+impl<B: MemSize, C: MemSize> MemSize for core::ops::ControlFlow<B, C> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        core::mem::size_of::<Self>()
+            + match self {
+                core::ops::ControlFlow::Break(b) => {
+                    <B as MemSize>::mem_size_rec(b, flags, refs) - core::mem::size_of::<B>()
+                }
+                core::ops::ControlFlow::Continue(c) => {
+                    <C as MemSize>::mem_size_rec(c, flags, refs) - core::mem::size_of::<C>()
+                }
+            }
+    }
+}
+
+impl<T: FlatType> FlatType for core::task::Poll<T> {
+    type Flat = T::Flat;
+}
+
+impl<T: MemSize> MemSize for core::task::Poll<T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        core::mem::size_of::<Self>()
+            + match self {
+                core::task::Poll::Ready(t) => {
+                    <T as MemSize>::mem_size_rec(t, flags, refs) - core::mem::size_of::<T>()
+                }
+                core::task::Poll::Pending => 0,
+            }
+    }
+}
+
+impl<T: FlatType> FlatType for core::ops::Bound<T> {
+    type Flat = T::Flat;
+}
+
+impl<T: MemSize> MemSize for core::ops::Bound<T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        core::mem::size_of::<Self>()
+            + match self {
+                core::ops::Bound::Included(t) | core::ops::Bound::Excluded(t) => {
+                    <T as MemSize>::mem_size_rec(t, flags, refs) - core::mem::size_of::<T>()
+                }
+                core::ops::Bound::Unbounded => 0,
+            }
+    }
+}
+
+impl<T: FlatType> FlatType for core::cmp::Reverse<T> {
+    type Flat = T::Flat;
+}
+
+impl<T: MemSize> MemSize for core::cmp::Reverse<T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        core::mem::size_of::<Self>() + <T as MemSize>::mem_size_rec(&self.0, flags, refs)
+            - core::mem::size_of::<T>()
+    }
+}
+
 // Box: unique ownership, so just recurse directly
 
 impl<T: ?Sized> FlatType for Box<T> {

--- a/mem_dbg/tests/test_core_wrapper_impls.rs
+++ b/mem_dbg/tests/test_core_wrapper_impls.rs
@@ -136,7 +136,8 @@ fn test_individual_wrapper_sizes() -> anyhow::Result<()> {
 fn test_niche_optimized_wrappers() -> anyhow::Result<()> {
     use core::num::NonZeroU32;
 
-    let leaked: &'static u8 = Box::leak(Box::new(7u8));
+    let backing = 7u8;
+    let stack_ref: &u8 = &backing;
 
     // `Poll` has two variants and a single niche from `&u8` is enough to
     // encode `Pending`, so the layout collapses to a single pointer.
@@ -145,7 +146,7 @@ fn test_niche_optimized_wrappers() -> anyhow::Result<()> {
         core::mem::size_of::<&u8>(),
     );
     let pending: core::task::Poll<&u8> = core::task::Poll::Pending;
-    let ready: core::task::Poll<&u8> = core::task::Poll::Ready(leaked);
+    let ready: core::task::Poll<&u8> = core::task::Poll::Ready(stack_ref);
     assert_eq!(
         pending.mem_size(SizeFlags::default()),
         core::mem::size_of::<core::task::Poll<&u8>>(),
@@ -161,7 +162,7 @@ fn test_niche_optimized_wrappers() -> anyhow::Result<()> {
         core::mem::size_of::<core::ops::ControlFlow<&u8, ()>>(),
         core::mem::size_of::<&u8>(),
     );
-    let flow_break: core::ops::ControlFlow<&u8, ()> = core::ops::ControlFlow::Break(leaked);
+    let flow_break: core::ops::ControlFlow<&u8, ()> = core::ops::ControlFlow::Break(stack_ref);
     let flow_continue: core::ops::ControlFlow<&u8, ()> = core::ops::ControlFlow::Continue(());
     assert_eq!(
         flow_break.mem_size(SizeFlags::default()),
@@ -178,7 +179,7 @@ fn test_niche_optimized_wrappers() -> anyhow::Result<()> {
         core::mem::size_of::<core::cmp::Reverse<&u8>>(),
         core::mem::size_of::<&u8>(),
     );
-    let reverse = core::cmp::Reverse(leaked);
+    let reverse = core::cmp::Reverse(stack_ref);
     assert_eq!(
         reverse.mem_size(SizeFlags::default()),
         core::mem::size_of::<core::cmp::Reverse<&u8>>(),

--- a/mem_dbg/tests/test_core_wrapper_impls.rs
+++ b/mem_dbg/tests/test_core_wrapper_impls.rs
@@ -1,0 +1,124 @@
+#![cfg(all(feature = "std", feature = "derive"))]
+
+//! Core wrapper fields should delegate accounting and debug traversal to the
+//! payload variant that is actually present.
+
+use mem_dbg::*;
+
+fn boxed_usize_payload_size() -> usize {
+    core::mem::size_of::<usize>()
+}
+
+#[derive(MemSize, MemDbg)]
+#[mem_size(rec)]
+struct ActiveWrapperFields {
+    reverse: core::cmp::Reverse<Box<usize>>,
+    bound: core::ops::Bound<Box<usize>>,
+    poll: core::task::Poll<Box<usize>>,
+    flow_break: core::ops::ControlFlow<Box<usize>, Box<usize>>,
+    flow_continue: core::ops::ControlFlow<Box<usize>, Box<usize>>,
+}
+
+#[derive(MemSize, MemDbg)]
+#[mem_size(rec)]
+struct EmptyWrapperFields {
+    bound: core::ops::Bound<Box<usize>>,
+    poll: core::task::Poll<Box<usize>>,
+}
+
+#[test]
+fn active_wrapper_payloads_are_accounted_and_debuggable() {
+    let node = ActiveWrapperFields {
+        reverse: core::cmp::Reverse(Box::new(1)),
+        bound: core::ops::Bound::Included(Box::new(2)),
+        poll: core::task::Poll::Ready(Box::new(3)),
+        flow_break: core::ops::ControlFlow::Break(Box::new(4)),
+        flow_continue: core::ops::ControlFlow::Continue(Box::new(5)),
+    };
+
+    assert_eq!(
+        node.mem_size(SizeFlags::default()),
+        core::mem::size_of::<ActiveWrapperFields>() + 5 * boxed_usize_payload_size()
+    );
+
+    let mut output = String::new();
+    node.mem_dbg_depth_on(&mut output, 2, DbgFlags::default())
+        .unwrap();
+    assert!(output.contains("ActiveWrapperFields"));
+    assert!(output.contains("reverse"));
+    assert!(output.contains("bound"));
+    assert!(output.contains("poll"));
+    assert!(output.contains("flow_break"));
+    assert!(output.contains("flow_continue"));
+}
+
+#[test]
+fn empty_wrapper_variants_have_no_payload_contribution() {
+    let node = EmptyWrapperFields {
+        bound: core::ops::Bound::Unbounded,
+        poll: core::task::Poll::Pending,
+    };
+
+    assert_eq!(
+        node.mem_size(SizeFlags::default()),
+        core::mem::size_of::<EmptyWrapperFields>()
+    );
+
+    let mut output = String::new();
+    node.mem_dbg_depth_on(&mut output, 2, DbgFlags::default())
+        .unwrap();
+    assert!(output.contains("EmptyWrapperFields"));
+    assert!(output.contains("bound"));
+    assert!(output.contains("poll"));
+}
+
+#[test]
+fn individual_wrapper_sizes_match_active_payloads() {
+    let reverse = core::cmp::Reverse(Box::new(1usize));
+    assert_eq!(
+        reverse.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::cmp::Reverse<Box<usize>>>() + boxed_usize_payload_size()
+    );
+
+    let included = core::ops::Bound::Included(Box::new(1usize));
+    let excluded = core::ops::Bound::Excluded(Box::new(1usize));
+    let unbounded: core::ops::Bound<Box<usize>> = core::ops::Bound::Unbounded;
+    assert_eq!(
+        included.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::ops::Bound<Box<usize>>>() + boxed_usize_payload_size()
+    );
+    assert_eq!(
+        excluded.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::ops::Bound<Box<usize>>>() + boxed_usize_payload_size()
+    );
+    assert_eq!(
+        unbounded.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::ops::Bound<Box<usize>>>()
+    );
+
+    let ready = core::task::Poll::Ready(Box::new(1usize));
+    let pending: core::task::Poll<Box<usize>> = core::task::Poll::Pending;
+    assert_eq!(
+        ready.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::task::Poll<Box<usize>>>() + boxed_usize_payload_size()
+    );
+    assert_eq!(
+        pending.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::task::Poll<Box<usize>>>()
+    );
+
+    let flow_break: core::ops::ControlFlow<Box<usize>, Box<usize>> =
+        core::ops::ControlFlow::Break(Box::new(1usize));
+    let flow_continue: core::ops::ControlFlow<Box<usize>, Box<usize>> =
+        core::ops::ControlFlow::Continue(Box::new(1usize));
+    assert_eq!(
+        flow_break.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::ops::ControlFlow<Box<usize>, Box<usize>>>()
+            + boxed_usize_payload_size()
+    );
+    assert_eq!(
+        flow_continue.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::ops::ControlFlow<Box<usize>, Box<usize>>>()
+            + boxed_usize_payload_size()
+    );
+}

--- a/mem_dbg/tests/test_core_wrapper_impls.rs
+++ b/mem_dbg/tests/test_core_wrapper_impls.rs
@@ -122,3 +122,94 @@ fn individual_wrapper_sizes_match_active_payloads() {
             + boxed_usize_payload_size()
     );
 }
+
+/// Niche-optimised payloads must not be double-counted: `mem_size` has to
+/// match the compiler-computed `size_of::<Self>()` for every variant, including
+/// when the discriminant is folded into the payload's invalid bit pattern. See
+/// `test_mem_size::test_exotic` for the equivalent `Option<&T>` regression.
+#[test]
+fn niche_optimized_wrappers_match_size_of() {
+    use core::num::NonZeroU32;
+
+    let leaked: &'static u8 = Box::leak(Box::new(7u8));
+
+    // `Poll` has two variants and a single niche from `&u8` is enough to
+    // encode `Pending`, so the layout collapses to a single pointer.
+    assert_eq!(
+        core::mem::size_of::<core::task::Poll<&u8>>(),
+        core::mem::size_of::<&u8>(),
+    );
+    let pending: core::task::Poll<&u8> = core::task::Poll::Pending;
+    let ready: core::task::Poll<&u8> = core::task::Poll::Ready(leaked);
+    assert_eq!(
+        pending.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::task::Poll<&u8>>(),
+    );
+    assert_eq!(
+        ready.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::task::Poll<&u8>>(),
+    );
+
+    // `ControlFlow<&u8, ()>` likewise collapses: `Continue(())` is a ZST so
+    // the null pointer encodes it.
+    assert_eq!(
+        core::mem::size_of::<core::ops::ControlFlow<&u8, ()>>(),
+        core::mem::size_of::<&u8>(),
+    );
+    let flow_break: core::ops::ControlFlow<&u8, ()> = core::ops::ControlFlow::Break(leaked);
+    let flow_continue: core::ops::ControlFlow<&u8, ()> = core::ops::ControlFlow::Continue(());
+    assert_eq!(
+        flow_break.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::ops::ControlFlow<&u8, ()>>(),
+    );
+    assert_eq!(
+        flow_continue.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::ops::ControlFlow<&u8, ()>>(),
+    );
+
+    // `Reverse` is `repr(transparent)` so it inherits the niche of its
+    // payload.
+    assert_eq!(
+        core::mem::size_of::<core::cmp::Reverse<&u8>>(),
+        core::mem::size_of::<&u8>(),
+    );
+    let reverse = core::cmp::Reverse(leaked);
+    assert_eq!(
+        reverse.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::cmp::Reverse<&u8>>(),
+    );
+
+    // `NonZeroU32` carries a single niche; `Option`/`Poll` collapse to four
+    // bytes while `Bound` (three variants) keeps a separate tag. In every
+    // case the formula must agree with `size_of::<Self>()`.
+    let nz = NonZeroU32::new(5).unwrap();
+    assert_eq!(core::mem::size_of::<Option<NonZeroU32>>(), 4);
+    assert_eq!(core::mem::size_of::<core::task::Poll<NonZeroU32>>(), 4);
+    let poll_nz_ready = core::task::Poll::<NonZeroU32>::Ready(nz);
+    let poll_nz_pending: core::task::Poll<NonZeroU32> = core::task::Poll::Pending;
+    assert_eq!(
+        poll_nz_ready.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::task::Poll<NonZeroU32>>(),
+    );
+    assert_eq!(
+        poll_nz_pending.mem_size(SizeFlags::default()),
+        core::mem::size_of::<core::task::Poll<NonZeroU32>>(),
+    );
+
+    let bound_nz_included = core::ops::Bound::<NonZeroU32>::Included(nz);
+    let bound_nz_excluded = core::ops::Bound::<NonZeroU32>::Excluded(nz);
+    let bound_nz_unbounded: core::ops::Bound<NonZeroU32> = core::ops::Bound::Unbounded;
+    let bound_nz_size = core::mem::size_of::<core::ops::Bound<NonZeroU32>>();
+    assert_eq!(
+        bound_nz_included.mem_size(SizeFlags::default()),
+        bound_nz_size
+    );
+    assert_eq!(
+        bound_nz_excluded.mem_size(SizeFlags::default()),
+        bound_nz_size
+    );
+    assert_eq!(
+        bound_nz_unbounded.mem_size(SizeFlags::default()),
+        bound_nz_size
+    );
+}

--- a/mem_dbg/tests/test_core_wrapper_impls.rs
+++ b/mem_dbg/tests/test_core_wrapper_impls.rs
@@ -3,6 +3,7 @@
 //! Core wrapper fields should delegate accounting and debug traversal to the
 //! payload variant that is actually present.
 
+use anyhow::Context;
 use mem_dbg::*;
 
 fn boxed_usize_payload_size() -> usize {
@@ -27,7 +28,7 @@ struct EmptyWrapperFields {
 }
 
 #[test]
-fn active_wrapper_payloads_are_accounted_and_debuggable() {
+fn test_active_wrapper_payloads() -> anyhow::Result<()> {
     let node = ActiveWrapperFields {
         reverse: core::cmp::Reverse(Box::new(1)),
         bound: core::ops::Bound::Included(Box::new(2)),
@@ -42,18 +43,19 @@ fn active_wrapper_payloads_are_accounted_and_debuggable() {
     );
 
     let mut output = String::new();
-    node.mem_dbg_depth_on(&mut output, 2, DbgFlags::default())
-        .unwrap();
+    node.mem_dbg_depth_on(&mut output, 2, DbgFlags::default())?;
     assert!(output.contains("ActiveWrapperFields"));
     assert!(output.contains("reverse"));
     assert!(output.contains("bound"));
     assert!(output.contains("poll"));
     assert!(output.contains("flow_break"));
     assert!(output.contains("flow_continue"));
+
+    Ok(())
 }
 
 #[test]
-fn empty_wrapper_variants_have_no_payload_contribution() {
+fn test_empty_wrapper_variants() -> anyhow::Result<()> {
     let node = EmptyWrapperFields {
         bound: core::ops::Bound::Unbounded,
         poll: core::task::Poll::Pending,
@@ -65,15 +67,16 @@ fn empty_wrapper_variants_have_no_payload_contribution() {
     );
 
     let mut output = String::new();
-    node.mem_dbg_depth_on(&mut output, 2, DbgFlags::default())
-        .unwrap();
+    node.mem_dbg_depth_on(&mut output, 2, DbgFlags::default())?;
     assert!(output.contains("EmptyWrapperFields"));
     assert!(output.contains("bound"));
     assert!(output.contains("poll"));
+
+    Ok(())
 }
 
 #[test]
-fn individual_wrapper_sizes_match_active_payloads() {
+fn test_individual_wrapper_sizes() -> anyhow::Result<()> {
     let reverse = core::cmp::Reverse(Box::new(1usize));
     assert_eq!(
         reverse.mem_size(SizeFlags::default()),
@@ -121,6 +124,8 @@ fn individual_wrapper_sizes_match_active_payloads() {
         core::mem::size_of::<core::ops::ControlFlow<Box<usize>, Box<usize>>>()
             + boxed_usize_payload_size()
     );
+
+    Ok(())
 }
 
 /// Niche-optimised payloads must not be double-counted: `mem_size` has to
@@ -128,7 +133,7 @@ fn individual_wrapper_sizes_match_active_payloads() {
 /// when the discriminant is folded into the payload's invalid bit pattern. See
 /// `test_mem_size::test_exotic` for the equivalent `Option<&T>` regression.
 #[test]
-fn niche_optimized_wrappers_match_size_of() {
+fn test_niche_optimized_wrappers() -> anyhow::Result<()> {
     use core::num::NonZeroU32;
 
     let leaked: &'static u8 = Box::leak(Box::new(7u8));
@@ -182,7 +187,7 @@ fn niche_optimized_wrappers_match_size_of() {
     // `NonZeroU32` carries a single niche; `Option`/`Poll` collapse to four
     // bytes while `Bound` (three variants) keeps a separate tag. In every
     // case the formula must agree with `size_of::<Self>()`.
-    let nz = NonZeroU32::new(5).unwrap();
+    let nz = NonZeroU32::new(5).context("5 is non-zero")?;
     assert_eq!(core::mem::size_of::<Option<NonZeroU32>>(), 4);
     assert_eq!(core::mem::size_of::<core::task::Poll<NonZeroU32>>(), 4);
     let poll_nz_ready = core::task::Poll::<NonZeroU32>::Ready(nz);
@@ -212,4 +217,6 @@ fn niche_optimized_wrappers_match_size_of() {
         bound_nz_unbounded.mem_size(SizeFlags::default()),
         bound_nz_size
     );
+
+    Ok(())
 }


### PR DESCRIPTION
Added more missing implementations for core types, including:

* ControlFlow
* Poll
* Reverse
* Bound