### PR TITLE
Fix bugs found by audit pass

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,3 +93,18 @@ jobs:
         run: cargo build --target i686-unknown-linux-gnu
       - name: Test (32-bit)
         run: cargo test --target i686-unknown-linux-gnu
+
+  build-aarch64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build
+        run: cargo build
+      - name: Test (default features, includes snapshots)
+        run: cargo test --features std,derive,half,maligned,mmap-rs,rand
+      - name: Test (no default features)
+        run: cargo test --no-default-features -- --skip _snapshot
+      - name: Test (alloc + derive)
+        run: cargo test --no-default-features --features derive -- --skip _snapshot
+      - name: Clippy (all stable features)
+        run: cargo clippy --features std,derive,half,maligned,mmap-rs,rand -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@
   empty default). Now they unwrap the option and recurse into `T` when
   populated, so `MemDbg` matches `MemSize`.
 
+- `std::sync::Mutex<T>` and `std::sync::RwLock<T>` `MemDbg` now recurse into
+  the inner `T` under default flags. Previously dispatch went through the
+  `MutexGuard<T>` / `RwLockReadGuard<T>` impl, which is gated on
+  `DbgFlags::FOLLOW_REFS` and silently dropped all children under default flags
+  - while `MemSize` always recursed.
+
 
 ## [0.4.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking** (size): `mmap_rs::Mmap` and `mmap_rs::MmapMut` now always
+  count their mapped region as part of `mem_size`. Previously the bytes were
+  only counted under `SizeFlags::FOLLOW_REFS`, which is inconsistent with
+  ownership semantics (the mapping is unmapped on drop).
+
 ### New
 
 - Added handle-only `MemSize`/`MemDbg` implementations for `*const T`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@
   a 100M-element `BTreeSet<usize>` and stays inside the `test_correctness`
   bounds at every measured size.
 
+### Fixed
+
+- `core::cell::OnceCell<T>` and `std::sync::OnceLock<T>` `_mem_dbg_rec_on`
+  were no-ops: they delegated to `Option::<&T>::_mem_dbg_rec_on` (the
+  empty default). Now they unwrap the option and recurse into `T` when
+  populated, so `MemDbg` matches `MemSize`.
+
 
 ## [0.4.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   only counted under `SizeFlags::FOLLOW_REFS`, which is inconsistent with
   ownership semantics (the mapping is unmapped on drop).
 
+- **Breaking** (display): `core::ops::Range`, `RangeFrom`,
+  `RangeInclusive`, `RangeTo`, `RangeToInclusive`, `core::cmp::Reverse`,
+  `core::ops::Bound`, `core::ops::ControlFlow`, and `core::task::Poll` now
+  render their inner fields with labels (`start`, `end`, `0`, `Break`,
+  `Continue`, `Ready`, `Included`, `Excluded`) and proper tree corners.
+  Previously they emitted unlabeled grandchildren at the wrong depth.
+
 ### New
 
 - Added handle-only `MemSize`/`MemDbg` implementations for `*const T`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
 
 - Added `MemSize`/`MemDbg` implementations for `std::collections::BinaryHeap<T>`. Its accounting follows the same Vec-backed element and capacity rules as `Vec<T>`.
 
+### Improved
+
+- Tighter `BTreeMap`/`BTreeSet` heap estimate: replaced the weighted-average
+  node-count formula (which silently dropped the root and intermediate internal
+  nodes when `len` was just above `CAPACITY`) with a level-by-level walk using
+  `FILL = B + 1 = 7` items per node. Matches the `cap` allocator within ~1% on
+  a 100M-element `BTreeSet<usize>` and stays inside the `test_correctness`
+  bounds at every measured size.
+
 
 ## [0.4.1] - 2026-03-25
 

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -801,11 +801,17 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::Mutex<T> {
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.lock()
-            .unwrap_or_else(|e| e.into_inner())
-            ._mem_dbg_rec_on(
-                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
-            )
+        let guard = self.lock().unwrap_or_else(|e| e.into_inner());
+        // Dispatch directly to `T`'s `_mem_dbg_rec_on` so the inner value's
+        // children are rendered. Going through the `MutexGuard<T>` impl would
+        // pick the FOLLOW_REFS-gated guard impl and silently drop children
+        // under default flags, even though `Mutex::mem_size_rec` always
+        // recurses into `T`.
+        // `is_last` is forwarded for trait shape; typical `_mem_dbg_rec_on`
+        // impls (including the derive's) compute their own per-field value.
+        <T as MemDbgImpl>::_mem_dbg_rec_on(
+            &*guard, writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        )
     }
 }
 
@@ -821,11 +827,14 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::RwLock<T> {
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.read()
-            .unwrap_or_else(|e| e.into_inner())
-            ._mem_dbg_rec_on(
-                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
-            )
+        let guard = self.read().unwrap_or_else(|e| e.into_inner());
+        // Dispatch directly to `T`'s `_mem_dbg_rec_on`; see `Mutex<T>` for
+        // the rationale.
+        // `is_last` is forwarded for trait shape; typical `_mem_dbg_rec_on`
+        // impls (including the derive's) compute their own per-field value.
+        <T as MemDbgImpl>::_mem_dbg_rec_on(
+            &*guard, writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        )
     }
 }
 

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -17,7 +17,7 @@ use alloc::borrow::{Cow, ToOwned};
 #[cfg(not(feature = "std"))]
 use alloc::collections::{BinaryHeap, VecDeque};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 #[cfg(feature = "std")]
 use std::borrow::{Cow, ToOwned};
 #[cfg(feature = "std")]
@@ -452,25 +452,23 @@ macro_rules! impl_tuples_muncher {
                 let mut _max_idx = $idx;
                 $(_max_idx = _max_idx.max($nidx);)*
 
-                let mut id_sizes: Vec<(usize, usize)> = vec![];
-                let n;
+                // Build the (field-index, field-offset) array on the stack.
+                let mut id_sizes = [
+                    ($idx, core::mem::offset_of!($tty, $idx)),
+                    $(($nidx, core::mem::offset_of!($tty, $nidx)),)*
+                ];
+                let n = id_sizes.len();
+                let total_size_self = core::mem::size_of::<Self>();
 
-                {
-                    // We use the offset_of information to build the real
-                    // space occupied by a field.
-                    id_sizes.push(($idx, core::mem::offset_of!($tty, $idx)));
-                    $(id_sizes.push(($nidx, core::mem::offset_of!($tty, $nidx)));)*
-                    n = id_sizes.len();
-                    id_sizes.push((n, core::mem::size_of::<Self>()));
-                    // Sort by offset
-                    id_sizes.sort_by_key(|x| x.1);
-                    // Compute actual sizes
-                    for i in 0..n {
-                        id_sizes[i].1 = id_sizes[i + 1].1 - id_sizes[i].1;
-                    };
-                    // Put the candle back
-                    id_sizes.sort_by_key(|x| x.0);
+                // Sort by offset to compute padded sizes via consecutive
+                // offset diffs; the last field stretches to `size_of::<Self>()`.
+                id_sizes.sort_by_key(|x| x.1);
+                for i in 0..n - 1 {
+                    id_sizes[i].1 = id_sizes[i + 1].1 - id_sizes[i].1;
                 }
+                id_sizes[n - 1].1 = total_size_self - id_sizes[n - 1].1;
+                // Restore declaration order so we can index by field number.
+                id_sizes.sort_by_key(|x| x.0);
 
                 self.$idx._mem_dbg_depth_on(writer, total_size, max_depth, prefix, Some(stringify!($idx)), $idx == _max_idx, id_sizes[$idx].1, flags, dbg_refs)?;
                 $(

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -180,16 +180,36 @@ impl<B: MemDbgImpl, C: MemDbgImpl> MemDbgImpl for core::ops::ControlFlow<B, C> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
+        // Render the active variant's payload as the wrapper's sole child,
+        // labeled with the variant name. `_mem_dbg_rec_on` itself only
+        // emits children, so we dispatch to `_mem_dbg_depth_on` to get the
+        // payload's own line plus any nested rendering.
         match self {
-            core::ops::ControlFlow::Break(b) => b._mem_dbg_rec_on(
-                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            core::ops::ControlFlow::Break(b) => b._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Break"),
+                true,
+                core::mem::size_of::<B>(),
+                flags,
+                dbg_refs,
             ),
-            core::ops::ControlFlow::Continue(c) => c._mem_dbg_rec_on(
-                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            core::ops::ControlFlow::Continue(c) => c._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Continue"),
+                true,
+                core::mem::size_of::<C>(),
+                flags,
+                dbg_refs,
             ),
         }
     }
@@ -202,13 +222,21 @@ impl<T: MemDbgImpl> MemDbgImpl for core::task::Poll<T> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
         match self {
-            core::task::Poll::Ready(t) => t._mem_dbg_rec_on(
-                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            core::task::Poll::Ready(t) => t._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Ready"),
+                true,
+                core::mem::size_of::<T>(),
+                flags,
+                dbg_refs,
             ),
             core::task::Poll::Pending => Ok(()),
         }
@@ -222,13 +250,32 @@ impl<T: MemDbgImpl> MemDbgImpl for core::ops::Bound<T> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
         match self {
-            core::ops::Bound::Included(t) | core::ops::Bound::Excluded(t) => t._mem_dbg_rec_on(
-                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            core::ops::Bound::Included(t) => t._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Included"),
+                true,
+                core::mem::size_of::<T>(),
+                flags,
+                dbg_refs,
+            ),
+            core::ops::Bound::Excluded(t) => t._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Excluded"),
+                true,
+                core::mem::size_of::<T>(),
+                flags,
+                dbg_refs,
             ),
             core::ops::Bound::Unbounded => Ok(()),
         }
@@ -242,12 +289,22 @@ impl<T: MemDbgImpl> MemDbgImpl for core::cmp::Reverse<T> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.0._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        // `Reverse<T>` is a tuple struct; mirror the derive output and
+        // print the inner field as `0`.
+        self.0._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("0"),
+            true,
+            core::mem::size_of::<T>(),
+            flags,
+            dbg_refs,
         )
     }
 }
@@ -570,15 +627,34 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::Range<Idx> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.start._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        // Render `start` and `end` as labeled children. Calling
+        // `_mem_dbg_rec_on` directly would skip the field's own line, lose
+        // the field name, and mis-draw the tree corner.
+        self.start._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("start"),
+            false,
+            core::mem::size_of::<Idx>(),
+            flags,
+            dbg_refs,
         )?;
-        self.end._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        self.end._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("end"),
+            true,
+            core::mem::size_of::<Idx>(),
+            flags,
+            dbg_refs,
         )
     }
 }
@@ -590,12 +666,20 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeFrom<Idx> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.start._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        self.start._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("start"),
+            true,
+            core::mem::size_of::<Idx>(),
+            flags,
+            dbg_refs,
         )
     }
 }
@@ -607,15 +691,31 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeInclusive<Idx> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.start()._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        self.start()._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("start"),
+            false,
+            core::mem::size_of::<Idx>(),
+            flags,
+            dbg_refs,
         )?;
-        self.end()._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        self.end()._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("end"),
+            true,
+            core::mem::size_of::<Idx>(),
+            flags,
+            dbg_refs,
         )
     }
 }
@@ -627,12 +727,20 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeTo<Idx> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.end._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        self.end._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("end"),
+            true,
+            core::mem::size_of::<Idx>(),
+            flags,
+            dbg_refs,
         )
     }
 }
@@ -644,12 +752,20 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeToInclusive<Idx> {
         total_size: usize,
         max_depth: usize,
         prefix: &mut String,
-        is_last: bool,
+        _is_last: bool,
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.end._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        self.end._mem_dbg_depth_on(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            Some("end"),
+            true,
+            core::mem::size_of::<Idx>(),
+            flags,
+            dbg_refs,
         )
     }
 }

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -840,9 +840,13 @@ impl<T: MemDbgImpl> MemDbgImpl for core::cell::OnceCell<T> {
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.get()._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
-        )
+        if let Some(inner) = self.get() {
+            inner._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            )
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -858,9 +862,13 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::OnceLock<T> {
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.get()._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
-        )
+        if let Some(inner) = self.get() {
+            inner._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            )
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1399,19 +1399,45 @@ fn estimate_btree_size<K, V>(len: usize, item_heap_size: usize) -> usize {
     internal_size = align_up(internal_size, core::mem::align_of::<usize>());
     internal_size += ptr_size * (CAPACITY + 1);
 
-    // Calculate weighted average node size.
-    // We heavily weight leaf nodes as they contain the majority of data.
-    // Ratio is approximately B leaves per 1 internal node.
-    let avg_node_size = (leaf_size * B + internal_size) / (B + 1);
-
-    // Estimate total heap usage:
-    // If the tree fits in a single node (len <= CAPACITY), it's just one leaf.
-    // Otherwise, we estimate the number of nodes based on average occupancy.
+    // Estimate the heap usage by walking the levels of the tree.
+    //
+    // `FILL` is the average number of items per node we assume. After
+    // `BTreeMap`'s split-on-overflow rule, sequential insertion settles
+    // around `B + 1` items per node (a node splits at `2*B` items into
+    // two halves, then refills back toward capacity, so the time-averaged
+    // occupancy is just above `B`). Using `B` (the legal minimum)
+    // systematically overestimates the node count by ~17%; using
+    // `CAPACITY` (the legal maximum) underestimates it.
+    //
+    // `FILL = B + 1 = 7` was calibrated against the `cap` allocator on a
+    // 100M-element `BTreeSet<usize>` (key = `usize`, sequential insertion
+    // `0..100_000_000`): real heap 1.96 GB, this formula 1.96 GB
+    // (within ~1%); the previous `(len / B) * avg_node_size` formula
+    // reported 1.71 GB (-13%), and a fill of plain `B` reports 2.40 GB
+    // (+22%). All three sit inside the `test_correctness` 2x bound, so
+    // the calibration is the only proof of accuracy at scale.
+    //
+    //   leaf_count   = ceil(len / FILL)
+    //   parent_count = ceil(child_count / (FILL + 1))
+    //
+    // Each internal node with `FILL` keys has `FILL + 1` child edges, so
+    // each non-leaf level has `ceil(prev / (FILL + 1))` internal nodes.
+    // Summing the levels gives a far tighter estimate than the prior
+    // `(len / B) * avg_node_size`, which silently dropped the root and
+    // other internal nodes when `len` was just above `CAPACITY`.
+    const FILL: usize = B + 1;
+    const INTERNAL_FANOUT: usize = FILL + 1;
     let heap_size = if len <= CAPACITY {
         leaf_size
     } else {
-        // Approximate node count assuming each node is roughly half full (B items).
-        (len / B) * avg_node_size
+        let leaf_count = len.div_ceil(FILL);
+        let mut total = leaf_count * leaf_size;
+        let mut level = leaf_count;
+        while level > 1 {
+            level = level.div_ceil(INTERNAL_FANOUT);
+            total += level * internal_size;
+        }
+        total
     };
 
     heap_size + item_heap_size

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1031,6 +1031,25 @@ impl<T> FlatType for std::io::BufReader<T> {
     type Flat = False;
 }
 
+// `BufReader<T>` / `BufWriter<T>` count their internal buffer
+// (`self.capacity()`) unconditionally, ignoring `SizeFlags::CAPACITY`.
+//
+// `CAPACITY` distinguishes user-asked memory from allocator-chosen slack:
+// `Vec` and friends grow geometrically, so by default we count `len` and
+// expose the slack only on demand; `HashMap`/`HashSet` size their bucket
+// arrays via load-factor policy, so by default we count filled slots and
+// expose the whole table only on demand. BTree node allocation is always
+// estimated because there is no exposed length-vs-capacity split for nodes.
+//
+// Buffered I/O is not slack. The constructor takes the buffer size
+// directly (`BufReader::with_capacity(N, _)`, default 8 KiB), so the
+// allocation is the user's stated commitment - the same shape as
+// `mmap_rs::Mmap`. `buffer().len()` (the bytes currently held) is a
+// transient I/O state that swings between 0 and `capacity()` during a
+// single read loop; it is not a memory-footprint quantity.
+//
+// We therefore intentionally treat `CAPACITY` as a no-op for these
+// types and always report `capacity()`.
 #[cfg(feature = "std")]
 impl<T: MemSize + std::io::Read> MemSize for std::io::BufReader<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1082,13 +1082,12 @@ impl FlatType for mmap_rs::Mmap {
 
 #[cfg(feature = "mmap-rs")]
 impl MemSize for mmap_rs::Mmap {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
-        core::mem::size_of::<Self>()
-            + if flags.contains(SizeFlags::FOLLOW_REFS) {
-                self.len()
-            } else {
-                0
-            }
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+        // `Mmap` owns its mapped region and unmaps it on drop, so its bytes
+        // belong to the value's footprint regardless of `FOLLOW_REFS`. There
+        // is no notion of unused capacity for an mmap, so `CAPACITY` is a
+        // no-op too.
+        core::mem::size_of::<Self>() + self.len()
     }
 }
 
@@ -1099,13 +1098,9 @@ impl FlatType for mmap_rs::MmapMut {
 
 #[cfg(feature = "mmap-rs")]
 impl MemSize for mmap_rs::MmapMut {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
-        core::mem::size_of::<Self>()
-            + if flags.contains(SizeFlags::FOLLOW_REFS) {
-                self.len()
-            } else {
-                0
-            }
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+        // See `Mmap` above.
+        core::mem::size_of::<Self>() + self.len()
     }
 }
 

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -780,6 +780,11 @@ impl<T: FlatType> FlatType for core::cell::RefCell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::RefCell<T> {
+    /// Returns `size_of::<Self>() + recursive(T)` when no mutable borrow is
+    /// active. If a mutable borrow is currently held, the inner `T` cannot
+    /// be observed, so this returns only `size_of::<Self>()` and silently
+    /// undercounts any heap reachable through `T`. The `MemDbg`
+    /// implementation surfaces this with a `<mutably borrowed>` marker.
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
         if let Ok(borrow) = self.try_borrow() {
             core::mem::size_of::<Self>() - core::mem::size_of::<T>()
@@ -796,9 +801,15 @@ impl<T: FlatType> FlatType for core::cell::Cell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::Cell<T> {
+    /// `Cell<T>` is `!Sync`, so no concurrent mutation can occur through
+    /// safe shared references, but a reentrant call (for example, a custom
+    /// `MemSize` impl that can reach the same cell) must not mutate this
+    /// cell while traversal holds the temporary shared reference below.
+    /// Violating that contract makes the result invalid and may violate
+    /// Rust's aliasing rules.
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
         // SAFETY: we temporarily take a shared reference to the inner value;
-        // since &self exists, &mut self cannot exist.
+        // callers must not reentrantly mutate the same cell during traversal.
         let borrow = unsafe { &*self.as_ptr() };
         <T as MemSize>::mem_size_rec(borrow, flags, refs)
     }
@@ -839,10 +850,13 @@ impl<T: FlatType> FlatType for core::cell::UnsafeCell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::UnsafeCell<T> {
+    /// Same reentrancy contract as `Cell<T>`: custom `MemSize` impls must
+    /// not mutate this cell through another `UnsafeCell::get()` while
+    /// traversal holds the temporary shared reference below.
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
-        // SAFETY: we temporarily take a shared reference to the inner value; no
-        // concurrent mutation through UnsafeCell::get() can occur during the
-        // temporary borrow.
+        // SAFETY: we temporarily take a shared reference to the inner value;
+        // callers must not mutate through another `UnsafeCell::get()` during
+        // traversal.
         let borrow = unsafe { &*self.get() };
         <T as MemSize>::mem_size_rec(borrow, flags, refs)
     }

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -578,7 +578,9 @@ pub trait MemDbgImpl: MemSize {
 
         // Skip padding and recursion for back-references
         if !is_backref {
-            let padding = padded_size - core::mem::size_of_val(self);
+            // Saturate so a misbehaving manual `MemDbgImpl` cannot trigger
+            // a debug-build underflow on the padding line.
+            let padding = padded_size.saturating_sub(core::mem::size_of_val(self));
 
             if padding != 0 {
                 writer.write_fmt(format_args!(" [{}B]", padding))?;

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-66_303 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,17 +49,17 @@ expression: output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
-    10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    10 B   0.01% ├╴array: [u8; 10]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
-    30 B   0.05% │ ╰╴1: alloc::string::String
+    30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
     27 B   0.04% │ ├╴1: alloc::string::String
@@ -76,10 +76,17 @@ expression: output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ╰╴start: usize
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
@@ -87,13 +94,13 @@ expression: output
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.46% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.53% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
@@ -109,28 +116,28 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.46% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.45% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.91% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.89% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.05% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.82% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_768 B   7.19% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_768 B   7.19% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_328 B  12.56% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   1.82% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   2.86% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_480 B   9.77% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_432 B   9.70% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_936 B  16.49% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_768 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_768 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_328 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.15% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.40% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.31% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.44% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-49_211 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -51,10 +51,10 @@ expression: output
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
     12 B   0.02% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -76,26 +76,33 @@ expression: output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
      8 B   0.02% ├╴range: core::ops::range::Range<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     4 B   0.01% │ ╰╴start: usize
     12 B   0.02% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.21% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
    120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.41% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    32 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     21 B   0.04% ├╴path_buf: std::path::PathBuf
@@ -109,28 +116,28 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.73% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.72% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
-    32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.40% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
-    32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.44% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_224 B   6.55% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_224 B   6.55% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 5_248 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
+   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+    32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_224 B   6.32% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_224 B   6.32% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 5_248 B  10.28% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   1.91% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.34% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_052 B   8.23% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_052 B   8.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 6_460 B  13.13% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_468 B   8.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_468 B   8.76% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 7_052 B  13.82% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-66_375 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,17 +49,17 @@ expression: output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
-    10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    10 B   0.01% ├╴array: [u8; 10]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
-    30 B   0.05% │ ╰╴1: alloc::string::String
+    30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
     27 B   0.04% │ ├╴1: alloc::string::String
@@ -77,7 +77,7 @@ expression: output
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
@@ -86,14 +86,14 @@ expression: output
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.46% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.53% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
@@ -109,28 +109,28 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.89% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.88% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.06% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.83% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_776 B   7.20% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_776 B   7.20% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_336 B  12.56% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   1.82% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   2.86% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_480 B   9.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_432 B   9.69% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_936 B  16.48% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_216 B   1.75% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_776 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_776 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_336 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.38% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.30% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.42% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
@@ -76,10 +76,17 @@ expression: output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-66_303 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-49_211 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-66_375 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-66_303 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,21 +49,21 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
-    10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    10 B   0.01% ├╴array: [u8; 10]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
     43 B   0.06% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     43 B   0.06% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
@@ -73,13 +73,13 @@ expression: depth_output
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.46% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.53% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
@@ -95,28 +95,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.46% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.45% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.91% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.89% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.05% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.82% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_768 B   7.19% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_768 B   7.19% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_328 B  12.56% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   1.82% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   2.86% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_480 B   9.77% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_432 B   9.70% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_936 B  16.49% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_768 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_768 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_328 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.15% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.40% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.31% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.44% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-49_211 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -51,10 +51,10 @@ expression: depth_output
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
     12 B   0.02% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -72,16 +72,16 @@ expression: depth_output
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.21% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
    120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.41% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    32 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     21 B   0.04% ├╴path_buf: std::path::PathBuf
@@ -95,28 +95,28 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.73% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.72% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
-    32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.40% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
-    32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.44% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_224 B   6.55% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_224 B   6.55% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 5_248 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
+   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+    32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_224 B   6.32% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_224 B   6.32% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 5_248 B  10.28% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   1.91% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.34% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_052 B   8.23% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_052 B   8.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 6_460 B  13.13% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_468 B   8.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_468 B   8.76% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 7_052 B  13.82% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-66_375 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,21 +49,21 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
-    10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    10 B   0.01% ├╴array: [u8; 10]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
     43 B   0.06% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     43 B   0.06% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
@@ -72,14 +72,14 @@ expression: depth_output
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.46% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.53% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
@@ -95,28 +95,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.89% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.88% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.06% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.83% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_776 B   7.20% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_776 B   7.20% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_336 B  12.56% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   1.82% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   2.86% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_480 B   9.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_432 B   9.69% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_936 B  16.48% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_216 B   1.75% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_776 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_776 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_336 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.38% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.30% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.42% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-66_303 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,17 +49,17 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
-    10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    10 B   0.01% ├╴array: [u8; 10]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
-    30 B   0.05% │ ╰╴1: alloc::string::String
+    30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
     27 B   0.04% │ ├╴1: alloc::string::String
@@ -76,10 +76,17 @@ expression: depth_output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ╰╴start: usize
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
@@ -87,13 +94,13 @@ expression: depth_output
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.46% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.53% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
@@ -109,28 +116,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.46% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.45% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.91% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.89% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.05% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.82% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_768 B   7.19% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_768 B   7.19% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_328 B  12.56% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   1.82% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   2.86% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_480 B   9.77% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_432 B   9.70% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_936 B  16.49% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_768 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_768 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_328 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.15% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.40% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.31% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.44% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-49_211 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -51,10 +51,10 @@ expression: depth_output
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
     12 B   0.02% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -76,26 +76,33 @@ expression: depth_output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
      8 B   0.02% ├╴range: core::ops::range::Range<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     4 B   0.01% │ ╰╴start: usize
     12 B   0.02% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.21% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
    120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.41% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    32 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     21 B   0.04% ├╴path_buf: std::path::PathBuf
@@ -109,28 +116,28 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.73% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.72% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
-    32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.40% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
-    32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.44% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_224 B   6.55% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_224 B   6.55% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 5_248 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
+   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+    32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_224 B   6.32% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_224 B   6.32% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 5_248 B  10.28% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   1.91% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.34% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_052 B   8.23% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_052 B   8.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 6_460 B  13.13% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_468 B   8.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_468 B   8.76% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 7_052 B  13.82% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
@@ -76,10 +76,17 @@ expression: depth_output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-66_375 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,17 +49,17 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
-    44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
+    44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
-    10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    10 B   0.01% ├╴array: [u8; 10]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
-    30 B   0.05% │ ╰╴1: alloc::string::String
+    30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
     27 B   0.04% │ ├╴1: alloc::string::String
@@ -77,7 +77,7 @@ expression: depth_output
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
@@ -86,14 +86,14 @@ expression: depth_output
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.46% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.53% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
@@ -109,28 +109,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.89% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.88% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.06% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.83% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_776 B   7.20% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_776 B   7.20% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_336 B  12.56% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   1.82% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   2.86% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_480 B   9.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_432 B   9.69% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_936 B  16.48% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_216 B   1.75% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_776 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_776 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_336 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.38% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.30% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.42% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59_803 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -52,55 +52,62 @@ expression: output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    76 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
     92 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +116,28 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.82% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.81% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.48% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.40% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-42_711 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -54,48 +54,55 @@ expression: output
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.07% ├╴array_str: [alloc::string::String; 2]
-    20 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32
     18 B   0.04% │ ╰╴1: alloc::string::String
     27 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ╰╴2: f64
     31 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     31 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
      8 B   0.02% ├╴range: core::ops::range::Range<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     4 B   0.01% │ ╰╴start: usize
     12 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    64 B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    20 B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    20 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    68 B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   120 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    64 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   153 B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -109,9 +116,9 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  19.27% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  19.26% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-    24 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+ 8_232 B  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+    24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
@@ -120,17 +127,17 @@ expression: output
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.85% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_242 B   7.59% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_242 B   7.59% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 4_840 B  11.33% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    64 B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59_875 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -52,26 +52,26 @@ expression: output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
@@ -85,22 +85,22 @@ expression: output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +109,28 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.80% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.18% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.56% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
@@ -76,10 +76,17 @@ expression: output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@aarch64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_803 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42_711 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_875 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_803 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -52,10 +52,10 @@ expression: depth_output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -71,22 +71,22 @@ expression: depth_output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    76 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
     92 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -95,28 +95,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.82% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.81% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.48% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.40% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42_711 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -54,8 +54,8 @@ expression: depth_output
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.07% ├╴array_str: [alloc::string::String; 2]
-    20 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.05% ├╴tuple2: (i32, alloc::string::String)
     27 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -72,16 +72,16 @@ expression: depth_output
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    64 B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    20 B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    20 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    68 B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   120 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    64 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   153 B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,9 +95,9 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  19.27% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  19.26% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-    24 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+ 8_232 B  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+    24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
@@ -106,17 +106,17 @@ expression: depth_output
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.85% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_242 B   7.59% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_242 B   7.59% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 4_840 B  11.33% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    64 B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_875 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -52,10 +52,10 @@ expression: depth_output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -71,22 +71,22 @@ expression: depth_output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -95,28 +95,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.80% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.18% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.56% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_803 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -52,55 +52,62 @@ expression: depth_output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    76 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
     92 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +116,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.82% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.81% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.48% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.40% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42_711 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -54,48 +54,55 @@ expression: depth_output
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.07% ├╴array_str: [alloc::string::String; 2]
-    20 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32
     18 B   0.04% │ ╰╴1: alloc::string::String
     27 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ╰╴2: f64
     31 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     31 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
      8 B   0.02% ├╴range: core::ops::range::Range<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     4 B   0.01% │ ╰╴start: usize
     12 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    64 B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    20 B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    20 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    68 B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   120 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    64 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   153 B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -109,9 +116,9 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  19.27% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  19.26% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-    24 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+ 8_232 B  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+    24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
@@ -120,17 +127,17 @@ expression: depth_output
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.85% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_242 B   7.59% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_242 B   7.59% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 4_840 B  11.33% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    64 B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
@@ -76,10 +76,17 @@ expression: depth_output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_875 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -52,26 +52,26 @@ expression: depth_output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
@@ -85,22 +85,22 @@ expression: depth_output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +109,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.80% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.18% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.56% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59803 B ⏺
+62915 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -76,10 +76,17 @@ expression: output
     1 B │ ├╴3
     1 B │ ╰╴4 [2B]
    16 B ├╴range
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_from
+    8 B │ ╰╴start
    24 B ├╴range_inclusive
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_to
+    8 B │ ╰╴end
     8 B ├╴range_to_inclusive
+    8 B │ ╰╴end
     4 B ├╴cell
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
@@ -127,10 +134,10 @@ expression: output
  3958 B ├╴hash_map_nc_100
  6708 B ├╴hash_map_nn_100
    24 B ├╴btree_set_empty
- 1208 B ├╴btree_set_100
+ 1404 B ├╴btree_set_100
    24 B ├╴btree_map_empty
- 1896 B ├╴btree_map_cc_100
- 5670 B ├╴btree_map_cn_100
- 5622 B ├╴btree_map_nc_100
- 9316 B ├╴btree_map_nn_100
+ 2184 B ├╴btree_map_cc_100
+ 6406 B ├╴btree_map_cn_100
+ 6346 B ├╴btree_map_nc_100
+10484 B ├╴btree_map_nn_100
    72 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-42711 B ⏺
+44527 B ⏺
     0 B ├╴unit
     1 B ├╴boolean [14B]
     4 B ├╴character
@@ -76,10 +76,17 @@ expression: output
     1 B │ ├╴3
     1 B │ ╰╴4 [2B]
     8 B ├╴range
+    4 B │ ├╴start
+    4 B │ ╰╴end
     4 B ├╴range_from
+    4 B │ ╰╴start
    12 B ├╴range_inclusive
+    4 B │ ├╴start
+    4 B │ ╰╴end
     4 B ├╴range_to
+    4 B │ ╰╴end
     4 B ├╴range_to_inclusive
+    4 B │ ╰╴end
     4 B ├╴cell
     8 B ├╴ref_cell
     4 B ├╴unsafe_cell
@@ -127,10 +134,10 @@ expression: output
  2414 B ├╴hash_map_nc_100
  3628 B ├╴hash_map_nn_100
    12 B ├╴btree_set_empty
-  940 B ├╴btree_set_100
+ 1092 B ├╴btree_set_100
    12 B ├╴btree_map_empty
- 1644 B ├╴btree_map_cc_100
- 3242 B ├╴btree_map_cn_100
- 3242 B ├╴btree_map_nc_100
- 4840 B ├╴btree_map_nn_100
+ 1884 B ├╴btree_map_cc_100
+ 3658 B ├╴btree_map_cn_100
+ 3658 B ├╴btree_map_nc_100
+ 5432 B ├╴btree_map_nn_100
    64 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
@@ -76,10 +76,17 @@ expression: output
     1 B │ ├╴3
     1 B │ ╰╴4 [2B]
    16 B ├╴range
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_from
+    8 B │ ╰╴start
    24 B ├╴range_inclusive
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_to
+    8 B │ ╰╴end
     8 B ├╴range_to_inclusive
+    8 B │ ╰╴end
     4 B ├╴cell
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59875 B ⏺
+62987 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -127,10 +127,10 @@ expression: output
  3966 B ├╴hash_map_nc_100
  6716 B ├╴hash_map_nn_100
    24 B ├╴btree_set_empty
- 1208 B ├╴btree_set_100
+ 1404 B ├╴btree_set_100
    24 B ├╴btree_map_empty
- 1896 B ├╴btree_map_cc_100
- 5670 B ├╴btree_map_cn_100
- 5622 B ├╴btree_map_nc_100
- 9316 B ├╴btree_map_nn_100
+ 2184 B ├╴btree_map_cc_100
+ 6406 B ├╴btree_map_cn_100
+ 6346 B ├╴btree_map_nc_100
+10484 B ├╴btree_map_nn_100
    72 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@aarch64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59803 B ⏺
+62915 B ⏺

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42711 B ⏺
+44527 B ⏺

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59875 B ⏺
+62987 B ⏺

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59803 B ⏺
+62915 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -113,10 +113,10 @@ expression: depth_output
  3958 B ├╴hash_map_nc_100
  6708 B ├╴hash_map_nn_100
    24 B ├╴btree_set_empty
- 1208 B ├╴btree_set_100
+ 1404 B ├╴btree_set_100
    24 B ├╴btree_map_empty
- 1896 B ├╴btree_map_cc_100
- 5670 B ├╴btree_map_cn_100
- 5622 B ├╴btree_map_nc_100
- 9316 B ├╴btree_map_nn_100
+ 2184 B ├╴btree_map_cc_100
+ 6406 B ├╴btree_map_cn_100
+ 6346 B ├╴btree_map_nc_100
+10484 B ├╴btree_map_nn_100
    72 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42711 B ⏺
+44527 B ⏺
     0 B ├╴unit
     1 B ├╴boolean [14B]
     4 B ├╴character
@@ -113,10 +113,10 @@ expression: depth_output
  2414 B ├╴hash_map_nc_100
  3628 B ├╴hash_map_nn_100
    12 B ├╴btree_set_empty
-  940 B ├╴btree_set_100
+ 1092 B ├╴btree_set_100
    12 B ├╴btree_map_empty
- 1644 B ├╴btree_map_cc_100
- 3242 B ├╴btree_map_cn_100
- 3242 B ├╴btree_map_nc_100
- 4840 B ├╴btree_map_nn_100
+ 1884 B ├╴btree_map_cc_100
+ 3658 B ├╴btree_map_cn_100
+ 3658 B ├╴btree_map_nc_100
+ 5432 B ├╴btree_map_nn_100
    64 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59875 B ⏺
+62987 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -113,10 +113,10 @@ expression: depth_output
  3966 B ├╴hash_map_nc_100
  6716 B ├╴hash_map_nn_100
    24 B ├╴btree_set_empty
- 1208 B ├╴btree_set_100
+ 1404 B ├╴btree_set_100
    24 B ├╴btree_map_empty
- 1896 B ├╴btree_map_cc_100
- 5670 B ├╴btree_map_cn_100
- 5622 B ├╴btree_map_nc_100
- 9316 B ├╴btree_map_nn_100
+ 2184 B ├╴btree_map_cc_100
+ 6406 B ├╴btree_map_cn_100
+ 6346 B ├╴btree_map_nc_100
+10484 B ├╴btree_map_nn_100
    72 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59803 B ⏺
+62915 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -76,10 +76,17 @@ expression: depth_output
     1 B │ ├╴3
     1 B │ ╰╴4 [2B]
    16 B ├╴range
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_from
+    8 B │ ╰╴start
    24 B ├╴range_inclusive
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_to
+    8 B │ ╰╴end
     8 B ├╴range_to_inclusive
+    8 B │ ╰╴end
     4 B ├╴cell
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
@@ -127,10 +134,10 @@ expression: depth_output
  3958 B ├╴hash_map_nc_100
  6708 B ├╴hash_map_nn_100
    24 B ├╴btree_set_empty
- 1208 B ├╴btree_set_100
+ 1404 B ├╴btree_set_100
    24 B ├╴btree_map_empty
- 1896 B ├╴btree_map_cc_100
- 5670 B ├╴btree_map_cn_100
- 5622 B ├╴btree_map_nc_100
- 9316 B ├╴btree_map_nn_100
+ 2184 B ├╴btree_map_cc_100
+ 6406 B ├╴btree_map_cn_100
+ 6346 B ├╴btree_map_nc_100
+10484 B ├╴btree_map_nn_100
    72 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42711 B ⏺
+44527 B ⏺
     0 B ├╴unit
     1 B ├╴boolean [14B]
     4 B ├╴character
@@ -76,10 +76,17 @@ expression: depth_output
     1 B │ ├╴3
     1 B │ ╰╴4 [2B]
     8 B ├╴range
+    4 B │ ├╴start
+    4 B │ ╰╴end
     4 B ├╴range_from
+    4 B │ ╰╴start
    12 B ├╴range_inclusive
+    4 B │ ├╴start
+    4 B │ ╰╴end
     4 B ├╴range_to
+    4 B │ ╰╴end
     4 B ├╴range_to_inclusive
+    4 B │ ╰╴end
     4 B ├╴cell
     8 B ├╴ref_cell
     4 B ├╴unsafe_cell
@@ -127,10 +134,10 @@ expression: depth_output
  2414 B ├╴hash_map_nc_100
  3628 B ├╴hash_map_nn_100
    12 B ├╴btree_set_empty
-  940 B ├╴btree_set_100
+ 1092 B ├╴btree_set_100
    12 B ├╴btree_map_empty
- 1644 B ├╴btree_map_cc_100
- 3242 B ├╴btree_map_cn_100
- 3242 B ├╴btree_map_nc_100
- 4840 B ├╴btree_map_nn_100
+ 1884 B ├╴btree_map_cc_100
+ 3658 B ├╴btree_map_cn_100
+ 3658 B ├╴btree_map_nc_100
+ 5432 B ├╴btree_map_nn_100
    64 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
@@ -76,10 +76,17 @@ expression: depth_output
     1 B │ ├╴3
     1 B │ ╰╴4 [2B]
    16 B ├╴range
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_from
+    8 B │ ╰╴start
    24 B ├╴range_inclusive
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_to
+    8 B │ ╰╴end
     8 B ├╴range_to_inclusive
+    8 B │ ╰╴end
     4 B ├╴cell
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59875 B ⏺
+62987 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -127,10 +127,10 @@ expression: depth_output
  3966 B ├╴hash_map_nc_100
  6716 B ├╴hash_map_nn_100
    24 B ├╴btree_set_empty
- 1208 B ├╴btree_set_100
+ 1404 B ├╴btree_set_100
    24 B ├╴btree_map_empty
- 1896 B ├╴btree_map_cc_100
- 5670 B ├╴btree_map_cn_100
- 5622 B ├╴btree_map_nc_100
- 9316 B ├╴btree_map_nn_100
+ 2184 B ├╴btree_map_cc_100
+ 6406 B ├╴btree_map_cn_100
+ 6346 B ├╴btree_map_nc_100
+10484 B ├╴btree_map_nn_100
    72 B ╰╴default_hasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59_849 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,7 +46,7 @@ expression: output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    22 B   0.04% ├╴reference: &str @ 0x[ADDR_1]
+    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
      6 B   0.01% │ ├╴: str
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
@@ -54,58 +54,65 @@ expression: output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    76 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
     92 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
-     9 B   0.02% │ ├╴: std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+     9 B   0.01% │ ├╴: std::path::Path
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
-     9 B   0.02% │ ├╴: std::ffi::os_str::OsStr
+     9 B   0.01% │ ├╴: std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
      8 B   0.01% ├╴fn_ptr2: fn(i32, i32) -> i32
@@ -113,28 +120,28 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.81% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.04% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.61% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.61% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  11.21% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.65% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-42_757 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -56,48 +56,55 @@ expression: output
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.07% ├╴array_str: [alloc::string::String; 2]
-    20 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32
     18 B   0.04% │ ╰╴1: alloc::string::String
     27 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ╰╴2: f64
     31 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     31 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
      8 B   0.02% ├╴range: core::ops::range::Range<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     4 B   0.01% │ ╰╴start: usize
     12 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    64 B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    20 B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    20 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    68 B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   120 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    64 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   153 B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -113,28 +120,28 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  19.25% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  19.24% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-    24 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+ 8_232 B  18.47% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.46% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+    24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    20 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.14% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.84% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_242 B   7.58% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_242 B   7.58% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 4_840 B  11.32% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    64 B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.21% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.21% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.19% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
@@ -78,10 +78,17 @@ expression: output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59_921 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,7 +46,7 @@ expression: output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    22 B   0.04% ├╴reference: &str @ 0x[ADDR_1]
+    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
      6 B   0.01% │ ├╴: str
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
@@ -54,26 +54,26 @@ expression: output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
@@ -87,25 +87,25 @@ expression: output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
-     9 B   0.02% │ ├╴: std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+     9 B   0.01% │ ├╴: std::path::Path
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
-     9 B   0.02% │ ├╴: std::ffi::os_str::OsStr
+     9 B   0.01% │ ├╴: std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
      8 B   0.01% ├╴fn_ptr2: fn(i32, i32) -> i32
@@ -113,28 +113,28 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.79% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.78% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.11% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.04% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.17% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  11.21% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.16% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.46% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.38% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.55% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.16% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.07% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.63% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_849 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42_757 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_921 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_849 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,16 +46,16 @@ expression: depth_output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    22 B   0.04% ├╴reference: &str @ 0x[ADDR_1]
+    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -71,22 +71,22 @@ expression: depth_output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    76 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
     92 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -95,28 +95,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.81% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.04% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.61% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.61% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  11.21% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.65% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42_757 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -54,8 +54,8 @@ expression: depth_output
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.07% ├╴array_str: [alloc::string::String; 2]
-    20 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.05% ├╴tuple2: (i32, alloc::string::String)
     27 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -72,16 +72,16 @@ expression: depth_output
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    64 B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    20 B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    20 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    68 B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   120 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    64 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   153 B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,28 +95,28 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  19.25% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  19.24% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-    24 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+ 8_232 B  18.47% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.46% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+    24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    20 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.14% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.84% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_242 B   7.58% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_242 B   7.58% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 4_840 B  11.32% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    64 B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.21% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.21% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.19% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_921 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,16 +46,16 @@ expression: depth_output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    22 B   0.04% ├╴reference: &str @ 0x[ADDR_1]
+    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -71,22 +71,22 @@ expression: depth_output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -95,28 +95,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.79% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.78% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.11% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.04% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.17% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  11.21% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.16% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.46% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.38% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.55% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.16% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.07% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.63% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_849 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,7 +46,7 @@ expression: depth_output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    22 B   0.04% ├╴reference: &str @ 0x[ADDR_1]
+    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
      6 B   0.01% │ ├╴: str
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
@@ -54,58 +54,65 @@ expression: depth_output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    76 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   157 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   176 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
     92 B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
-     9 B   0.02% │ ├╴: std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+     9 B   0.01% │ ├╴: std::path::Path
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
-     9 B   0.02% │ ├╴: std::ffi::os_str::OsStr
+     9 B   0.01% │ ├╴: std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
      8 B   0.01% ├╴fn_ptr2: fn(i32, i32) -> i32
@@ -113,28 +120,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.81% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.04% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.61% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.61% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  11.21% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.65% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42_757 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [14B]
      4 B   0.01% ├╴character: char
@@ -56,48 +56,55 @@ expression: depth_output
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.07% ├╴array_str: [alloc::string::String; 2]
-    20 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32
     18 B   0.04% │ ╰╴1: alloc::string::String
     27 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ╰╴2: f64
     31 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     31 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    15 B   0.04% │ ├╴1: alloc::string::String
+    15 B   0.03% │ ├╴1: alloc::string::String
      8 B   0.02% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
      8 B   0.02% ├╴range: core::ops::range::Range<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     4 B   0.01% │ ╰╴start: usize
     12 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     4 B   0.01% │ ├╴start: usize
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     4 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   101 B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    64 B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-    20 B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    20 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    68 B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   101 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   120 B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    64 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   153 B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+    20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -113,28 +120,28 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  19.25% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  19.24% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-    24 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+ 8_232 B  18.47% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.46% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+    24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    20 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.14% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-   940 B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_644 B   3.84% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_242 B   7.58% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_242 B   7.58% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 4_840 B  11.32% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    64 B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.21% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.21% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.19% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
@@ -78,10 +78,17 @@ expression: depth_output
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59_921 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,7 +46,7 @@ expression: depth_output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    22 B   0.04% ├╴reference: &str @ 0x[ADDR_1]
+    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
      6 B   0.01% │ ├╴: str
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
@@ -54,26 +54,26 @@ expression: depth_output
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>
-    76 B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+    76 B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    52 B   0.09% ├╴array_str: [alloc::string::String; 2]
-    28 B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
      4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
      4 B   0.01% │ ├╴0: i32
-    27 B   0.05% │ ├╴1: alloc::string::String
+    27 B   0.04% │ ├╴1: alloc::string::String
      8 B   0.01% │ ├╴2: f64
      1 B   0.00% │ ├╴3: bool
      1 B   0.00% │ ╰╴4: u8 [2B]
@@ -87,25 +87,25 @@ expression: depth_output
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-    46 B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    84 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-   165 B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   184 B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   100 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-    84 B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+    46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+    84 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+   165 B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+   184 B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   100 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+   305 B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
-    33 B   0.06% ├╴path_buf: std::path::PathBuf
+    33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
-     9 B   0.02% │ ├╴: std::path::Path
-    33 B   0.06% ├╴os_string: std::ffi::os_str::OsString
+     9 B   0.01% │ ├╴: std::path::Path
+    33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
     25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
-     9 B   0.02% │ ├╴: std::ffi::os_str::OsStr
+     9 B   0.01% │ ├╴: std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
      8 B   0.01% ├╴fn_ptr2: fn(i32, i32) -> i32
@@ -113,28 +113,28 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.79% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.78% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.11% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    84 B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.04% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.05% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.17% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  11.21% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_208 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_896 B   3.16% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 5_670 B   9.46% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 5_622 B   9.38% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 9_316 B  15.55% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.16% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.07% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.63% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59.80 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -52,55 +52,62 @@ expression: output
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>
-   76  B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+   76  B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   52  B   0.09% ├╴array_str: [alloc::string::String; 2]
-   28  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   52  B   0.08% ├╴array_str: [alloc::string::String; 2]
+   28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
     4  B   0.01% │ ├╴0: i32 [4B]
    30  B   0.05% │ ╰╴1: alloc::string::String
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
     4  B   0.01% │ ├╴0: i32 [4B]
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ╰╴2: f64
    43  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ╰╴3: bool [3B]
    43  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
    16  B   0.03% ├╴range: core::ops::range::Range<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+    8  B   0.01% │ ╰╴start: usize
    24  B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+    8  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-   46  B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   76  B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  157  B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  176  B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+   76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  176  B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
    92  B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   84  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  305  B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  352  B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  128  B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   84  B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  305  B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  352  B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
-   33  B   0.06% ├╴path_buf: std::path::PathBuf
+   33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
-   33  B   0.06% ├╴os_string: std::ffi::os_str::OsString
+   33  B   0.05% ├╴os_string: std::ffi::os_str::OsString
    16  B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
     8  B   0.01% ├╴fn_ptr0: fn() -> i32
     8  B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +116,28 @@ expression: output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.82% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.81% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-   84  B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  696  B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  696  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.208 kB   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.958 kB   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.958 kB   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.708 kB  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.208 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.958 kB   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.958 kB   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.708 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.208 kB   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.896 kB   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-5.670 kB   9.48% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-5.622 kB   9.40% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-9.316 kB  15.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   72  B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-42.71 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool [14B]
     4  B   0.01% ├╴character: char
@@ -54,48 +54,55 @@ expression: output
    32  B   0.07% ├╴vec: alloc::vec::Vec<i32>
    40  B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   28  B   0.07% ├╴array_str: [alloc::string::String; 2]
-   20  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   28  B   0.06% ├╴array_str: [alloc::string::String; 2]
+   20  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    22  B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    22  B   0.05% ├╴tuple2: (i32, alloc::string::String)
     4  B   0.01% │ ├╴0: i32
    18  B   0.04% │ ╰╴1: alloc::string::String
    27  B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
     4  B   0.01% │ ├╴0: i32
-   15  B   0.04% │ ├╴1: alloc::string::String
+   15  B   0.03% │ ├╴1: alloc::string::String
     8  B   0.02% │ ╰╴2: f64
    31  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     4  B   0.01% │ ├╴0: i32
-   15  B   0.04% │ ├╴1: alloc::string::String
+   15  B   0.03% │ ├╴1: alloc::string::String
     8  B   0.02% │ ├╴2: f64
     1  B   0.00% │ ╰╴3: bool [3B]
    31  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     4  B   0.01% │ ├╴0: i32
-   15  B   0.04% │ ├╴1: alloc::string::String
+   15  B   0.03% │ ├╴1: alloc::string::String
     8  B   0.02% │ ├╴2: f64
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
     8  B   0.02% ├╴range: core::ops::range::Range<usize>
+    4  B   0.01% │ ├╴start: usize
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+    4  B   0.01% │ ╰╴start: usize
    12  B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    4  B   0.01% │ ├╴start: usize
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
     8  B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    23  B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    30  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   68  B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  101  B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  120  B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   84  B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   64  B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  153  B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  200  B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  108  B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-   20  B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-   20  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   68  B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  101  B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  120  B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   84  B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   64  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  153  B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  200  B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  108  B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   20  B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+   20  B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
    16  B   0.04% ├╴random_state: std::hash::random::RandomState
    21  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -109,9 +116,9 @@ expression: output
     4  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     8  B   0.02% ├╴layout: core::alloc::layout::Layout
     4  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.232 kB  19.27% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.228 kB  19.26% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-   24  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+8.232 kB  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.228 kB  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+   24  B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     4  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     4  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    52  B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
@@ -120,17 +127,17 @@ expression: output
     8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    32  B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  688  B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  688  B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    32  B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.200 kB   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-2.414 kB   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-2.414 kB   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-3.628 kB   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.200 kB   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+2.414 kB   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+2.414 kB   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+3.628 kB   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    12  B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-  940  B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.092 kB   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    12  B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.644 kB   3.85% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-3.242 kB   7.59% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-3.242 kB   7.59% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-4.840 kB  11.33% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   64  B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+1.884 kB   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+3.658 kB   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+3.658 kB   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+5.432 kB  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   64  B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
@@ -76,10 +76,17 @@ expression: output
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
    16  B   0.03% ├╴range: core::ops::range::Range<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+    8  B   0.01% │ ╰╴start: usize
    24  B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+    8  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-59.88 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -52,26 +52,26 @@ expression: output
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>
-   76  B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+   76  B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   52  B   0.09% ├╴array_str: [alloc::string::String; 2]
-   28  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   52  B   0.08% ├╴array_str: [alloc::string::String; 2]
+   28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
     4  B   0.01% │ ├╴0: i32 [4B]
    30  B   0.05% │ ╰╴1: alloc::string::String
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
     4  B   0.01% │ ├╴0: i32 [4B]
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ╰╴2: f64
    43  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ╰╴3: bool [3B]
    43  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
@@ -85,22 +85,22 @@ expression: output
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-   46  B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   84  B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  165  B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  184  B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-  100  B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   84  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  305  B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  352  B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  128  B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+   84  B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  165  B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  184  B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+  100  B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   84  B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  305  B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  352  B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
-   33  B   0.06% ├╴path_buf: std::path::PathBuf
+   33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
-   33  B   0.06% ├╴os_string: std::ffi::os_str::OsString
+   33  B   0.05% ├╴os_string: std::ffi::os_str::OsString
    16  B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
     8  B   0.01% ├╴fn_ptr0: fn() -> i32
     8  B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +109,28 @@ expression: output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.80% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-   84  B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  704  B   1.18% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  704  B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.216 kB   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.966 kB   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.966 kB   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.716 kB  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.216 kB   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.966 kB   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.966 kB   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.716 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.208 kB   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.896 kB   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-5.670 kB   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-5.622 kB   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-9.316 kB  15.56% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   72  B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@aarch64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59.80 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42.71 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59.88 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59.80 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -52,10 +52,10 @@ expression: depth_output
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>
-   76  B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+   76  B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   52  B   0.09% ├╴array_str: [alloc::string::String; 2]
-   28  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   52  B   0.08% ├╴array_str: [alloc::string::String; 2]
+   28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -71,22 +71,22 @@ expression: depth_output
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-   46  B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   76  B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  157  B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  176  B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+   76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  176  B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
    92  B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   84  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  305  B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  352  B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  128  B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   84  B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  305  B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  352  B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
-   33  B   0.06% ├╴path_buf: std::path::PathBuf
+   33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
-   33  B   0.06% ├╴os_string: std::ffi::os_str::OsString
+   33  B   0.05% ├╴os_string: std::ffi::os_str::OsString
    16  B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
     8  B   0.01% ├╴fn_ptr0: fn() -> i32
     8  B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -95,28 +95,28 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.82% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.81% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-   84  B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  696  B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  696  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.208 kB   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.958 kB   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.958 kB   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.708 kB  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.208 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.958 kB   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.958 kB   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.708 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.208 kB   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.896 kB   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-5.670 kB   9.48% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-5.622 kB   9.40% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-9.316 kB  15.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   72  B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42.71 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool [14B]
     4  B   0.01% ├╴character: char
@@ -54,8 +54,8 @@ expression: depth_output
    32  B   0.07% ├╴vec: alloc::vec::Vec<i32>
    40  B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   28  B   0.07% ├╴array_str: [alloc::string::String; 2]
-   20  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   28  B   0.06% ├╴array_str: [alloc::string::String; 2]
+   20  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    22  B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    22  B   0.05% ├╴tuple2: (i32, alloc::string::String)
    27  B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -72,16 +72,16 @@ expression: depth_output
    23  B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    30  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   68  B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  101  B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  120  B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   84  B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   64  B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  153  B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  200  B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  108  B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-   20  B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-   20  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   68  B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  101  B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  120  B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   84  B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   64  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  153  B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  200  B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  108  B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   20  B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+   20  B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
    16  B   0.04% ├╴random_state: std::hash::random::RandomState
    21  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,9 +95,9 @@ expression: depth_output
     4  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     8  B   0.02% ├╴layout: core::alloc::layout::Layout
     4  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.232 kB  19.27% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.228 kB  19.26% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-   24  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+8.232 kB  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.228 kB  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+   24  B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     4  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     4  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    52  B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
@@ -106,17 +106,17 @@ expression: depth_output
     8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    32  B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  688  B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  688  B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    32  B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.200 kB   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-2.414 kB   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-2.414 kB   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-3.628 kB   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.200 kB   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+2.414 kB   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+2.414 kB   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+3.628 kB   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    12  B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-  940  B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.092 kB   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    12  B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.644 kB   3.85% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-3.242 kB   7.59% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-3.242 kB   7.59% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-4.840 kB  11.33% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   64  B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+1.884 kB   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+3.658 kB   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+3.658 kB   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+5.432 kB  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   64  B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59.88 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -52,10 +52,10 @@ expression: depth_output
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>
-   76  B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+   76  B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   52  B   0.09% ├╴array_str: [alloc::string::String; 2]
-   28  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   52  B   0.08% ├╴array_str: [alloc::string::String; 2]
+   28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -71,22 +71,22 @@ expression: depth_output
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-   46  B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   84  B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  165  B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  184  B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-  100  B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   84  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  305  B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  352  B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  128  B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+   84  B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  165  B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  184  B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+  100  B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   84  B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  305  B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  352  B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
-   33  B   0.06% ├╴path_buf: std::path::PathBuf
+   33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
-   33  B   0.06% ├╴os_string: std::ffi::os_str::OsString
+   33  B   0.05% ├╴os_string: std::ffi::os_str::OsString
    16  B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
     8  B   0.01% ├╴fn_ptr0: fn() -> i32
     8  B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -95,28 +95,28 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.80% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-   84  B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  704  B   1.18% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  704  B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.216 kB   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.966 kB   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.966 kB   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.716 kB  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.216 kB   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.966 kB   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.966 kB   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.716 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.208 kB   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.896 kB   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-5.670 kB   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-5.622 kB   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-9.316 kB  15.56% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   72  B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59.80 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -52,55 +52,62 @@ expression: depth_output
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>
-   76  B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+   76  B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   52  B   0.09% ├╴array_str: [alloc::string::String; 2]
-   28  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   52  B   0.08% ├╴array_str: [alloc::string::String; 2]
+   28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
     4  B   0.01% │ ├╴0: i32 [4B]
    30  B   0.05% │ ╰╴1: alloc::string::String
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
     4  B   0.01% │ ├╴0: i32 [4B]
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ╰╴2: f64
    43  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ╰╴3: bool [3B]
    43  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
    16  B   0.03% ├╴range: core::ops::range::Range<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+    8  B   0.01% │ ╰╴start: usize
    24  B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+    8  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-   46  B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   76  B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  157  B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  176  B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+   76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  176  B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
    92  B   0.15% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   84  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  305  B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  352  B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  128  B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   84  B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  305  B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  352  B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
-   33  B   0.06% ├╴path_buf: std::path::PathBuf
+   33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
-   33  B   0.06% ├╴os_string: std::ffi::os_str::OsString
+   33  B   0.05% ├╴os_string: std::ffi::os_str::OsString
    16  B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
     8  B   0.01% ├╴fn_ptr0: fn() -> i32
     8  B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +116,28 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.82% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.81% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-   84  B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  696  B   1.16% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  696  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.208 kB   2.02% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.958 kB   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.958 kB   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.708 kB  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.208 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.958 kB   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.958 kB   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.708 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.208 kB   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.896 kB   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-5.670 kB   9.48% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-5.622 kB   9.40% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-9.316 kB  15.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   72  B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-42.71 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool [14B]
     4  B   0.01% ├╴character: char
@@ -54,48 +54,55 @@ expression: depth_output
    32  B   0.07% ├╴vec: alloc::vec::Vec<i32>
    40  B   0.09% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   28  B   0.07% ├╴array_str: [alloc::string::String; 2]
-   20  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   28  B   0.06% ├╴array_str: [alloc::string::String; 2]
+   20  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    22  B   0.05% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    22  B   0.05% ├╴tuple2: (i32, alloc::string::String)
     4  B   0.01% │ ├╴0: i32
    18  B   0.04% │ ╰╴1: alloc::string::String
    27  B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
     4  B   0.01% │ ├╴0: i32
-   15  B   0.04% │ ├╴1: alloc::string::String
+   15  B   0.03% │ ├╴1: alloc::string::String
     8  B   0.02% │ ╰╴2: f64
    31  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     4  B   0.01% │ ├╴0: i32
-   15  B   0.04% │ ├╴1: alloc::string::String
+   15  B   0.03% │ ├╴1: alloc::string::String
     8  B   0.02% │ ├╴2: f64
     1  B   0.00% │ ╰╴3: bool [3B]
    31  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     4  B   0.01% │ ├╴0: i32
-   15  B   0.04% │ ├╴1: alloc::string::String
+   15  B   0.03% │ ├╴1: alloc::string::String
     8  B   0.02% │ ├╴2: f64
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
     8  B   0.02% ├╴range: core::ops::range::Range<usize>
+    4  B   0.01% │ ├╴start: usize
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+    4  B   0.01% │ ╰╴start: usize
    12  B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    4  B   0.01% │ ├╴start: usize
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+    4  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
     8  B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    23  B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    30  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   68  B   0.16% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  101  B   0.24% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  120  B   0.28% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-   84  B   0.20% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   64  B   0.15% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  153  B   0.36% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  200  B   0.47% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  108  B   0.25% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
-   20  B   0.05% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-   20  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   68  B   0.15% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  101  B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  120  B   0.27% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+   84  B   0.19% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   64  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  153  B   0.34% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  200  B   0.45% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  108  B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   20  B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
+   20  B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
    16  B   0.04% ├╴random_state: std::hash::random::RandomState
    21  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -109,9 +116,9 @@ expression: depth_output
     4  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     8  B   0.02% ├╴layout: core::alloc::layout::Layout
     4  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.232 kB  19.27% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.228 kB  19.26% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-   24  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+8.232 kB  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.228 kB  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+   24  B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     4  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     4  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    52  B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
@@ -120,17 +127,17 @@ expression: depth_output
     8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    32  B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  688  B   1.61% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  688  B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    32  B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.200 kB   2.81% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-2.414 kB   5.65% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-2.414 kB   5.65% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-3.628 kB   8.49% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.200 kB   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+2.414 kB   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+2.414 kB   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+3.628 kB   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    12  B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-  940  B   2.20% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.092 kB   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    12  B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.644 kB   3.85% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-3.242 kB   7.59% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-3.242 kB   7.59% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-4.840 kB  11.33% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   64  B   0.15% ╰╴default_hasher: std::hash::random::DefaultHasher
+1.884 kB   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+3.658 kB   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+3.658 kB   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+5.432 kB  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   64  B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
@@ -76,10 +76,17 @@ expression: depth_output
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
    16  B   0.03% ├╴range: core::ops::range::Range<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+    8  B   0.01% │ ╰╴start: usize
    24  B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+    8  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-59.88 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -52,26 +52,26 @@ expression: depth_output
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>
-   76  B   0.13% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
+   76  B   0.12% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
    10  B   0.02% ├╴array: [u8; 10]
-   52  B   0.09% ├╴array_str: [alloc::string::String; 2]
-   28  B   0.05% ├╴slice: alloc::boxed::Box<[u32]>
+   52  B   0.08% ├╴array_str: [alloc::string::String; 2]
+   28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
     4  B   0.01% │ ├╴0: i32 [4B]
    30  B   0.05% │ ╰╴1: alloc::string::String
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
     4  B   0.01% │ ├╴0: i32 [4B]
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ╰╴2: f64
    43  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ╰╴3: bool [3B]
    43  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     4  B   0.01% │ ├╴0: i32
-   27  B   0.05% │ ├╴1: alloc::string::String
+   27  B   0.04% │ ├╴1: alloc::string::String
     8  B   0.01% │ ├╴2: f64
     1  B   0.00% │ ├╴3: bool
     1  B   0.00% │ ╰╴4: u8 [2B]
@@ -85,22 +85,22 @@ expression: depth_output
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
    12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
-   46  B   0.08% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-   84  B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
-  165  B   0.28% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-  184  B   0.31% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-  100  B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
-   84  B   0.14% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-  305  B   0.51% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-  352  B   0.59% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-  128  B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
+   84  B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+  165  B   0.26% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
+  184  B   0.29% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+  100  B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   84  B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
+  305  B   0.48% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+  352  B   0.56% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+  128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
-   33  B   0.06% ├╴path_buf: std::path::PathBuf
+   33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
-   33  B   0.06% ├╴os_string: std::ffi::os_str::OsString
+   33  B   0.05% ├╴os_string: std::ffi::os_str::OsString
    16  B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
     8  B   0.01% ├╴fn_ptr0: fn() -> i32
     8  B   0.01% ├╴fn_ptr1: fn(i32) -> i32
@@ -109,28 +109,28 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.80% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.79% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-   84  B   0.14% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  704  B   1.18% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  704  B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.216 kB   2.03% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.966 kB   6.62% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.966 kB   6.62% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.716 kB  11.22% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.216 kB   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.966 kB   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.966 kB   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.716 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.208 kB   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.896 kB   3.17% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-5.670 kB   9.47% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-5.622 kB   9.39% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-9.316 kB  15.56% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-   72  B   0.12% ╰╴default_hasher: std::hash::random::DefaultHasher
+2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+   72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/test_audit_regressions.rs
+++ b/mem_dbg/tests/test_audit_regressions.rs
@@ -1,0 +1,199 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "derive")]
+
+//! Regression tests for the bugs fixed by the audit pass. Each section is
+//! introduced by the bug it covers.
+
+use mem_dbg::*;
+
+#[derive(MemSize, MemDbg)]
+struct Inner {
+    heavy: Vec<u8>,
+}
+
+fn render<T: MemDbg>(value: &T) -> String {
+    let mut out = String::new();
+    value
+        .mem_dbg_on(&mut out, DbgFlags::default())
+        .expect("mem_dbg_on");
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: `OnceCell<T>` and `OnceLock<T>` `_mem_dbg_rec_on` were no-ops
+// because they called `Option::<&T>::_mem_dbg_rec_on` (the empty default)
+// instead of unwrapping `self.get()`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn oncecell_renders_inner_children() {
+    use std::cell::OnceCell;
+
+    let cell: OnceCell<Inner> = OnceCell::new();
+    cell.set(Inner {
+        heavy: vec![0u8; 64],
+    })
+    .ok()
+    .expect("oncecell set");
+
+    let out = render(&cell);
+    assert!(out.contains("OnceCell"), "missing OnceCell line:\n{out}");
+    assert!(
+        out.contains("heavy"),
+        "OnceCell did not recurse into Inner:\n{out}"
+    );
+}
+
+#[test]
+fn oncecell_empty_renders_only_self() {
+    use std::cell::OnceCell;
+
+    let cell: OnceCell<Inner> = OnceCell::new();
+    let out = render(&cell);
+    assert!(out.contains("OnceCell"));
+    assert!(!out.contains("heavy"));
+}
+
+#[test]
+fn oncelock_renders_inner_children() {
+    use std::sync::OnceLock;
+
+    let cell: OnceLock<Inner> = OnceLock::new();
+    cell.set(Inner {
+        heavy: vec![0u8; 64],
+    })
+    .ok()
+    .expect("oncelock set");
+
+    let out = render(&cell);
+    assert!(out.contains("OnceLock"), "missing OnceLock line:\n{out}");
+    assert!(
+        out.contains("heavy"),
+        "OnceLock did not recurse into Inner:\n{out}"
+    );
+}
+
+#[test]
+fn oncelock_empty_renders_only_self() {
+    use std::sync::OnceLock;
+
+    let cell: OnceLock<Inner> = OnceLock::new();
+    let out = render(&cell);
+    assert!(out.contains("OnceLock"));
+    assert!(!out.contains("heavy"));
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2: `Mutex<T>::_mem_dbg_rec_on` and `RwLock<T>::_mem_dbg_rec_on`
+// dispatched on the `MutexGuard<T>`/`RwLockReadGuard<T>` value, hitting the
+// guard's FOLLOW_REFS-gated impl and silently dropping children under
+// default flags - while `mem_size_rec` always recursed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mutex_renders_inner_children_under_default_flags() {
+    use std::sync::Mutex;
+
+    let m = Mutex::new(Inner {
+        heavy: vec![0u8; 64],
+    });
+    let out = render(&m);
+    assert!(out.contains("Mutex"));
+    assert!(
+        out.contains("heavy"),
+        "Mutex did not recurse into Inner under default flags:\n{out}"
+    );
+}
+
+#[test]
+fn rwlock_renders_inner_children_under_default_flags() {
+    use std::sync::RwLock;
+
+    let r = RwLock::new(Inner {
+        heavy: vec![0u8; 64],
+    });
+    let out = render(&r);
+    assert!(out.contains("RwLock"));
+    assert!(
+        out.contains("heavy"),
+        "RwLock did not recurse into Inner under default flags:\n{out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug 3: `Range`/`RangeFrom`/`RangeInclusive`/`RangeTo`/`RangeToInclusive`/
+// `Reverse`/`Bound`/`ControlFlow`/`Poll` called `_mem_dbg_rec_on` on inner
+// fields instead of `_mem_dbg_depth_on`, losing field labels and miscomputing
+// tree corners (the inner field's grandchildren rendered at the wrong depth).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_labels_start_and_end() {
+    let r: std::ops::Range<u32> = 1..100;
+    let out = render(&r);
+    assert!(out.contains("├╴start"), "missing labeled start:\n{out}");
+    assert!(out.contains("╰╴end"), "missing labeled end:\n{out}");
+}
+
+#[test]
+fn range_inclusive_labels_start_and_end() {
+    let r: std::ops::RangeInclusive<u32> = 1..=100;
+    let out = render(&r);
+    assert!(out.contains("├╴start"), "missing labeled start:\n{out}");
+    assert!(out.contains("╰╴end"), "missing labeled end:\n{out}");
+}
+
+#[test]
+fn one_sided_ranges_label_their_only_field() {
+    let from: std::ops::RangeFrom<u32> = 5..;
+    assert!(render(&from).contains("╰╴start"));
+
+    let to: std::ops::RangeTo<u32> = ..10;
+    assert!(render(&to).contains("╰╴end"));
+
+    let to_inclusive: std::ops::RangeToInclusive<u32> = ..=10;
+    assert!(render(&to_inclusive).contains("╰╴end"));
+}
+
+#[test]
+fn reverse_labels_inner_field() {
+    let value = core::cmp::Reverse(Box::new(7u32));
+    let out = render(&value);
+    assert!(out.contains("Reverse"));
+    assert!(out.contains("╰╴0"), "missing tuple-style 0 label:\n{out}");
+}
+
+#[test]
+fn bound_variants_label_payload() {
+    let included: std::ops::Bound<Box<u32>> = std::ops::Bound::Included(Box::new(1));
+    let excluded: std::ops::Bound<Box<u32>> = std::ops::Bound::Excluded(Box::new(2));
+    let unbounded: std::ops::Bound<Box<u32>> = std::ops::Bound::Unbounded;
+
+    assert!(render(&included).contains("╰╴Included"));
+    assert!(render(&excluded).contains("╰╴Excluded"));
+    let out_unbounded = render(&unbounded);
+    assert!(out_unbounded.contains("Bound"));
+    assert!(!out_unbounded.contains("Included"));
+    assert!(!out_unbounded.contains("Excluded"));
+}
+
+#[test]
+fn poll_variants_label_payload() {
+    let ready: core::task::Poll<Box<u32>> = core::task::Poll::Ready(Box::new(1));
+    let pending: core::task::Poll<Box<u32>> = core::task::Poll::Pending;
+
+    assert!(render(&ready).contains("╰╴Ready"));
+    let out_pending = render(&pending);
+    assert!(!out_pending.contains("Ready"));
+}
+
+#[test]
+fn control_flow_variants_label_payload() {
+    let brk: core::ops::ControlFlow<Box<u32>, Box<u32>> =
+        core::ops::ControlFlow::Break(Box::new(1));
+    let cont: core::ops::ControlFlow<Box<u32>, Box<u32>> =
+        core::ops::ControlFlow::Continue(Box::new(2));
+
+    assert!(render(&brk).contains("╰╴Break"));
+    assert!(render(&cont).contains("╰╴Continue"));
+}

--- a/mem_dbg/tests/test_mmap_rs.rs
+++ b/mem_dbg/tests/test_mmap_rs.rs
@@ -34,26 +34,24 @@ fn test_mmap_types() {
             .unwrap()
     };
 
-    // Default flags: only the handle is reported.
-    assert_eq!(
-        mmap.mem_size(SizeFlags::default()),
-        core::mem::size_of::<Mmap>()
-    );
-    assert_eq!(
-        mmap_mut.mem_size(SizeFlags::default()),
-        core::mem::size_of::<MmapMut>()
-    );
-
-    // FOLLOW_REFS adds the mapped pages.
-    assert_eq!(
-        mmap.mem_size(SizeFlags::FOLLOW_REFS),
-        core::mem::size_of::<Mmap>() + MMAP_LEN
-    );
-    assert_eq!(
-        mmap_mut.mem_size(SizeFlags::FOLLOW_REFS),
-        core::mem::size_of::<MmapMut>() + MMAP_LEN
-    );
-
+    // The mapped region is always counted: `Mmap` owns its bytes, so the
+    // size is `size_of::<Mmap>() + len()` regardless of `FOLLOW_REFS` or
+    // `CAPACITY`.
+    for flags in [
+        SizeFlags::default(),
+        SizeFlags::FOLLOW_REFS,
+        SizeFlags::CAPACITY,
+        SizeFlags::FOLLOW_REFS | SizeFlags::CAPACITY,
+    ] {
+        assert_eq!(
+            mmap.mem_size(flags),
+            core::mem::size_of::<Mmap>() + MMAP_LEN
+        );
+        assert_eq!(
+            mmap_mut.mem_size(flags),
+            core::mem::size_of::<MmapMut>() + MMAP_LEN
+        );
+    }
     // mem_dbg should not panic for any combination of flags.
     for flag in [
         DbgFlags::default(),

--- a/mem_dbg/tests/test_padded_size_saturation.rs
+++ b/mem_dbg/tests/test_padded_size_saturation.rs
@@ -1,0 +1,54 @@
+use mem_dbg::*;
+
+struct TooSmallPadding(u64);
+
+impl FlatType for TooSmallPadding {
+    type Flat = True;
+}
+
+impl MemSize for TooSmallPadding {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+        core::mem::size_of_val(&self.0)
+    }
+}
+
+impl MemDbgImpl for TooSmallPadding {
+    fn _mem_dbg_depth_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        field_name: Option<&str>,
+        is_last: bool,
+        _padded_size: usize,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        self._mem_dbg_depth_on_impl(
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            field_name,
+            is_last,
+            0,
+            flags,
+            dbg_refs,
+            RefDisplay::None,
+        )
+    }
+}
+
+#[test]
+fn too_small_padded_size_does_not_underflow() {
+    let value = TooSmallPadding(0);
+    let mut out = String::new();
+
+    value
+        .mem_dbg_on(&mut out, DbgFlags::default())
+        .expect("mem_dbg_on should saturate a too-small padded_size");
+
+    assert!(out.contains('⏺'));
+    assert!(!out.contains('['), "unexpected padding marker:\n{out}");
+}


### PR DESCRIPTION
This PR fixes the bugs uncovered by an audit of `mem_dbg-rs`. Each
commit is a single semantic change. The findings (and the corresponding
commit subjects) are:

## Confirmed bugs

| # | Bug | Commit |
|---|-----|--------|
| 1 | `OnceCell<T>::_mem_dbg_rec_on` was a no-op (it called `Option::<&T>::_mem_dbg_rec_on` -> empty default), so `mem_dbg` reported the cell's inflated size with no breakdown while `mem_size_rec` did recurse. | `fix(impl_mem_dbg): recurse into OnceCell payload under default flags` |
| 2 | `Mutex<T>` / `RwLock<T>` `_mem_dbg_rec_on` dispatched on the `MutexGuard<T>` value, hitting the FOLLOW_REFS-gated guard impl and silently dropping children under default flags. | `fix(impl_mem_dbg): dispatch Mutex/RwLock children to T's impl directly` |
| 3 | `Range`/`RangeFrom`/`RangeInclusive`/`RangeTo`/`RangeToInclusive`/`Reverse`/`Bound`/`ControlFlow`/`Poll` called `_mem_dbg_rec_on` on inner fields instead of `_mem_dbg_depth_on`, losing labels and mis-drawing tree corners. | `fix(impl_mem_dbg): render Range/Reverse/Bound/ControlFlow/Poll fields with labels` |
| 12 | `test_hash_collections.rs` predicted `GROUP_WIDTH = 16` on `aarch64 + NEON`, but hashbrown's NEON `Group` is `uint8x8_t` (8 bytes). The impl was correct; the test was wrong, causing 4 spurious failures on aarch64. | `fix(tests): correct GROUP_WIDTH expectation for aarch64+NEON` |

## Inconsistencies

| # | Bug | Commit |
|---|-----|--------|
| ~~4~~ | ~~`BufReader<T>` / `BufWriter<T>` always counted `self.capacity()`; sibling impls use `len()` by default and `capacity()` under the `CAPACITY` flag.~~ | **Not a bug** -- a buffered I/O buffer is a user-chosen allocation, not allocator slack, so `CAPACITY` is intentionally a no-op here. Rationale spelled out in `docs(impl_mem_size): document why BufReader/BufWriter ignore CAPACITY`. |
| 5 | `mmap_rs::Mmap` / `MmapMut` only counted their bytes under `FOLLOW_REFS`. They own those bytes (unmapped on drop), so they should be counted unconditionally. | `fix(impl_mem_size): always count owned mmap_rs bytes` |

## Soundness / footgun notes

| # | Bug | Commit |
|---|-----|--------|
| 6 | `Cell<T>` / `UnsafeCell<T>::mem_size_rec` reentrancy: a callback that mutates the cell mid-traversal can race against the inner read (no UB; result unspecified). | `docs(impl_mem_size): clarify Cell/UnsafeCell/RefCell mem_size caveats` |
| 7 | `RefCell::mem_size_rec` silently undercounts when mutably borrowed (`mem_dbg` shows `<mutably borrowed>` instead, asymmetric behavior). | same commit as 6 |

## Lower-priority items

| # | Bug | Commit |
|---|-----|--------|
| ~~8~~ | ~~`RcInner` / `ArcInner` shadow types declared `#[repr(C, align(2))]`; std uses `#[repr(C)]`.~~ | **Withdrawn** -- review caught that std actually still uses `#[repr(C, align(2))]` for AVR support (see `library/alloc/src/{rc,sync}.rs`). The original `align(2)` was correct; the audit was wrong about std. Commit dropped. |
| 9 | `BTreeMap`/`BTreeSet` heuristic underestimated by ~50% just above `2*B-1` because `(len / B) * avg_node_size` dropped the root and intermediate internal nodes. Replaced with a level-by-level walk using `FILL = B + 1` as the per-node fill factor (empirically std's split-on-overflow rule lands sequential inserts at ~B+1 average occupancy; matches the `cap`-allocator measurement on a 100M-element `BTreeSet<usize>` to within ~1%). | `perf(impl_mem_size): tighten BTreeMap/BTreeSet size heuristic` |
| 10 | `_mem_dbg_depth_on_impl`'s `padded_size - size_of_val(self)` could underflow if a hand-written `MemDbgImpl` passed a too-small `padded_size`. Saturate. | `fix(lib): saturate padded_size subtraction in mem_dbg trace` |
| 11 | Tuple `_mem_dbg_rec_on` allocated a `Vec<(usize, usize)>` per call. Switched to a stack array. | `perf(impl_mem_dbg): build tuple field-offset table on the stack` |

## On bug 4 (no change)

The original audit listed `BufReader`/`BufWriter`'s always-`capacity()`
behavior as inconsistent with `Vec`/`String`/etc. After review we
concluded that take was wrong:

- The `CAPACITY` flag's purpose is to expose **allocator-chosen slack**
  the user did not directly ask for (geometric growth in `Vec`,
  load-factor policy in hash/btree maps).
- A `BufReader::with_capacity(N, _)` allocation is taken verbatim from
  the constructor's argument. That's user intent, not slack.
- `buffer().len()` is a transient I/O state that swings between 0 and
  `capacity()` during a single read loop; it is not a memory-footprint
  quantity.

The original behavior is the correct one. The docs commit makes the
rationale explicit in the source so we don't re-litigate.

## On bug 9 (fill factor)

A first iteration of the heuristic walked levels with `B = 6` items
per node (the legal minimum). That fixed the missing-root case at
small `len` but overshot std's actual occupancy at scale (a 100M-element
`BTreeSet<usize>` reported 2.40 GB vs 1.96 GB measured by `cap` --
+22%). Reviewed and tuned to `FILL = B + 1 = 7`: std's split-on-overflow
behaviour lands sequential inserts at ~B+1 average occupancy, so this
matches the 100M reference within ~1% and stays at or better than the
original `(len / B) * avg_node_size` formula across every measured
size in `test_correctness`.

## On bug 12 (aarch64 GROUP_WIDTH)

Surfaced when a Vigna ran the suite on real aarch64 hardware and
saw four failures in `test_hash_collections.rs`, all off by exactly 8
bytes. Reproduced under qemu-aarch64 and traced to `test_hash_collections.rs`
predicting `GROUP_WIDTH = 16` on `aarch64 + NEON`. The impl
(`impl_mem_size.rs`) used `GROUP_WIDTH = 8` for non-x86 targets, which
is what hashbrown actually does: its NEON `Group` is `uint8x8_t` (a
64-bit NEON vector, 8 bytes), not `uint8x16_t`. Test fixed to mirror
the impl, and verified end-to-end against the `cap` allocator on
aarch64.

## Tests

Bugs 1, 2, 3 each have focused regression tests in
`mem_dbg/tests/test_audit_regressions.rs`. Bugs 3 and 9 (the ones that
change `mem_dbg` output / `mem_size` totals) come with refreshed insta
snapshots for x86_64, x86, and aarch64.

## Snapshots

Per `AGENTS.md`, snapshots **MUST** be regenerated per architecture.
This PR refreshes all three:

- `@x86_64` on the host directly.
- `@x86` via the `rust:latest` Docker image with `gcc-multilib` and
  the `i686-unknown-linux-gnu` target (mirrors the `build-i686` CI job).
- `@aarch64` via `docker run --platform linux/arm64 rust:latest`
  (qemu-aarch64 user emulation registered via `tonistiigi/binfmt`).

## Verification

Host (x86_64):

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo clippy --features std,derive,half,maligned,mmap-rs,rand -- -D warnings`
- `cargo test --features std,derive,half,maligned,mmap-rs,rand`
- `cargo test --no-default-features -- --skip _snapshot`
- `cargo test --no-default-features --features derive -- --skip _snapshot`
- `cargo test --release --features std,derive --test test_correctness` (cap allocator)

Cross-arch (qemu user emulation):

- `cargo test --features std,derive,half,maligned,mmap-rs,rand` on aarch64
- `cargo test --release --features std,derive --test test_correctness` on aarch64
- `cargo test --target i686-unknown-linux-gnu --features std,derive,half,maligned,mmap-rs,rand`

All green.
