### PR TITLE
refactor!: drop hashbrown, use BTreeMap/BTreeSet for pointer dedup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,10 @@ jobs:
         run: cargo test --no-default-features -- --skip _snapshot
       - name: Run tests with alloc and derive feature
         run: cargo test --no-default-features --features derive -- --skip _snapshot
+      - name: Run no_std + hashbrown tests
+        run: cargo test --no-default-features --features hashbrown -- --skip _snapshot
+      - name: Run all stable features incl. hashbrown
+        run: cargo test --features std,derive,half,maligned,mmap-rs,rand,hashbrown -- --skip _snapshot
       - name: Run examples
         working-directory: ./mem_dbg
         run: |
@@ -29,8 +33,10 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Clippy (no default features)
         run: cargo clippy --no-default-features -- -D warnings
+      - name: Clippy (hashbrown only)
+        run: cargo clippy --no-default-features --features hashbrown -- -D warnings
       - name: Clippy (all stable features)
-        run: cargo clippy --features std,derive,half,maligned,mmap-rs,rand -- -D warnings
+        run: cargo clippy --features std,derive,half,maligned,mmap-rs,rand,hashbrown -- -D warnings
 
   build-nightly:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
 
 ### New
 
+- Added optional `hashbrown` feature. When enabled, provides
+  `MemSize`/`MemDbgImpl` implementations for `hashbrown::HashMap<K, V, S>`
+  and `hashbrown::HashSet<T, S>`, sharing the Swiss-table layout math
+  with the `std::collections` impls. `hashbrown` is pulled in only when
+  the feature is on, so non-feature users see no dependency. Lets `no_std`
+  users (where `std::collections::HashMap`/`HashSet` are unavailable)
+  account hash-collection memory.
+
 - Added handle-only `MemSize`/`MemDbg` implementations for `*const T`,
   `*mut T`, `std::rc::Weak<T>`, and `std::sync::Weak<T>`. None of these are
   followed: their referents are neither dereferenced nor counted, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**: dropped the `hashbrown` dependency. The pointer-dedup
+  containers used by the `MemSize` / `MemDbg` traits and emitted by the
+  derive macro are now `alloc::collections::BTreeMap<usize, usize>` and
+  `alloc::collections::BTreeSet<usize>`. Any manual `MemSize` /
+  `MemDbgImpl` implementation that named these parameters as
+  `&mut HashMap<usize, usize>` / `&mut HashSet<usize>` (the previous
+  `hashbrown` re-exports) **MUST** be updated. Code that uses
+  `#[derive(MemSize, MemDbg)]` is unaffected.
+
 ### New
 
 - Added handle-only `MemSize`/`MemDbg` implementations for `*const T`,

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ impl MemSize for IntOrFloatI {
     fn mem_size_rec(
         &self,
         _flags: SizeFlags,
-        _refs: &mut HashMap<usize, usize>,
+        _refs: &mut BTreeMap<usize, usize>,
     ) -> usize {
         core::mem::size_of::<Self>()
     }
@@ -381,7 +381,7 @@ impl MemDbgImpl for IntOrFloatI {
         prefix: &mut String,
         _is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         unsafe { self.0.i }._mem_dbg_depth_on(
             writer,
@@ -405,7 +405,7 @@ impl MemSize for IntOrFloatF {
     fn mem_size_rec(
         &self,
         _flags: SizeFlags,
-        _refs: &mut HashMap<usize, usize>,
+        _refs: &mut BTreeMap<usize, usize>,
     ) -> usize {
         core::mem::size_of::<Self>()
     }
@@ -420,7 +420,7 @@ impl MemDbgImpl for IntOrFloatF {
         prefix: &mut String,
         _is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         unsafe { self.0.f }._mem_dbg_depth_on(
             writer,

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ which however needs the nightly compiler, as it enables the unstable feature
 - `maligned`: support for the [`maligned`] crate.
 - `mmap-rs`: support for the [`mmap-rs`] crate.
 - `rand`: support for the [`rand`] crate.
+- `hashbrown`: support for the [`hashbrown`] crate. Useful in `no_std`
+  builds (where `std::collections::HashMap`/`HashSet` are unavailable);
+  in `std` builds it adds impls for `hashbrown` collections alongside the
+  `std` ones.
 
 ## Examples
 
@@ -457,6 +461,7 @@ w.mem_dbg(DbgFlags::empty())?;
 [`mmap-rs`]: https://crates.io/crates/mmap-rs
 [`half`]: https://crates.io/crates/half
 [`rand`]: https://crates.io/crates/rand
+[`hashbrown`]: https://crates.io/crates/hashbrown
 [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
 [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 [`DbgFlags::FOLLOW_REFS`]: https://docs.rs/mem_dbg/latest/mem_dbg/struct.DbgFlags.html#associatedconstant.FOLLOW_REFS

--- a/mem_dbg-derive/src/lib.rs
+++ b/mem_dbg-derive/src/lib.rs
@@ -130,7 +130,7 @@ pub fn mem_dbg_mem_size(input: TokenStream) -> TokenStream {
 
                 #[automatically_derived]
                 impl #impl_generics ::mem_dbg::MemSize for #input_ident #ty_generics #where_clause {
-                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::HashMap<usize, usize>) -> usize {
+                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::BTreeMap<usize, usize>) -> usize {
                         #const_assert
                         let mut bytes = ::core::mem::size_of::<Self>();
                         #(bytes += <#fields_ty as ::mem_dbg::MemSize>::mem_size_rec(&self.#fields_ident, _memsize_flags, _memsize_refs) - ::core::mem::size_of::<#fields_ty>();)*
@@ -236,7 +236,7 @@ pub fn mem_dbg_mem_size(input: TokenStream) -> TokenStream {
 
                 #[automatically_derived]
                 impl #impl_generics ::mem_dbg::MemSize for #input_ident #ty_generics #where_clause {
-                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::HashMap<usize, usize>) -> usize {
+                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::BTreeMap<usize, usize>) -> usize {
                         #const_assert
                         match self {
                             #(
@@ -317,7 +317,7 @@ pub fn mem_dbg_mem_dbg(input: TokenStream) -> TokenStream {
                         _memdbg_prefix: &mut String,
                         _memdbg_is_last: bool,
                         _memdbg_flags: ::mem_dbg::DbgFlags,
-                        _memdbg_refs: &mut ::mem_dbg::HashSet<usize>,
+                        _memdbg_refs: &mut ::mem_dbg::BTreeSet<usize>,
                     ) -> ::core::fmt::Result {
                         let mut id_sizes: Vec<(usize, usize, usize)> = vec![];
                         #(#id_offset_pushes)*
@@ -541,7 +541,7 @@ pub fn mem_dbg_mem_dbg(input: TokenStream) -> TokenStream {
                         _memdbg_prefix: &mut String,
                         _memdbg_is_last: bool,
                         _memdbg_flags: ::mem_dbg::DbgFlags,
-                        _memdbg_refs: &mut ::mem_dbg::HashSet<usize>,
+                        _memdbg_refs: &mut ::mem_dbg::BTreeSet<usize>,
                     ) -> ::core::fmt::Result {
                         let mut _memdbg_digits_number = ::mem_dbg::n_of_digits(_memdbg_total_size);
                         if _memdbg_flags.contains(::mem_dbg::DbgFlags::SEPARATOR) {

--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -22,7 +22,6 @@ mmap-rs = { version = "0.7.0", optional = true }
 half = { version = "2.0.4", optional = true }
 rand = { version = "0.10.0", optional = true }
 maligned = { version = "0.2.1", optional = true }
-hashbrown = "0.16"
 
 [dev-dependencies]
 anyhow = "1"

--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -22,6 +22,7 @@ mmap-rs = { version = "0.7.0", optional = true }
 half = { version = "2.0.4", optional = true }
 rand = { version = "0.10.0", optional = true }
 maligned = { version = "0.2.1", optional = true }
+hashbrown = { version = "0.16", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
@@ -38,6 +39,7 @@ default = ["std", "derive"]
 std = []
 derive = ["mem_dbg-derive"]
 maligned = ["dep:maligned"]
+hashbrown = ["dep:hashbrown"]
 offset_of_enum = ["derive", "mem_dbg-derive/offset_of_enum"]
 
 [[example]]

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -10,7 +10,7 @@ use core::marker::PhantomPinned;
 use core::num::*;
 use core::{marker::PhantomData, sync::atomic::*};
 
-use crate::{DbgFlags, FlatType, HashSet, MemDbgImpl, RefDisplay, impl_mem_size::MemSizeHelper};
+use crate::{BTreeSet, DbgFlags, FlatType, MemDbgImpl, RefDisplay, impl_mem_size::MemSizeHelper};
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::VecDeque;
@@ -45,7 +45,7 @@ macro_rules! impl_mem_dbg_for_deref {
             is_last: bool,
             padded_size: usize,
             flags: DbgFlags,
-            dbg_refs: &mut HashSet<usize>,
+            dbg_refs: &mut BTreeSet<usize>,
         ) -> core::fmt::Result {
             if flags.contains(DbgFlags::$flag) {
                 let $self = self;
@@ -102,7 +102,7 @@ macro_rules! impl_mem_dbg_for_deref {
             prefix: &mut String,
             is_last: bool,
             flags: DbgFlags,
-            dbg_refs: &mut HashSet<usize>,
+            dbg_refs: &mut BTreeSet<usize>,
         ) -> core::fmt::Result {
             // Only display inner type when following refs
             if flags.contains(DbgFlags::$flag) {
@@ -178,7 +178,7 @@ impl<B: MemDbgImpl, C: MemDbgImpl> MemDbgImpl for core::ops::ControlFlow<B, C> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         match self {
             core::ops::ControlFlow::Break(b) => b._mem_dbg_rec_on(
@@ -200,7 +200,7 @@ impl<T: MemDbgImpl> MemDbgImpl for core::task::Poll<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         match self {
             core::task::Poll::Ready(t) => t._mem_dbg_rec_on(
@@ -220,7 +220,7 @@ impl<T: MemDbgImpl> MemDbgImpl for core::ops::Bound<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         match self {
             core::ops::Bound::Included(t) | core::ops::Bound::Excluded(t) => t._mem_dbg_rec_on(
@@ -240,7 +240,7 @@ impl<T: MemDbgImpl> MemDbgImpl for core::cmp::Reverse<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.0._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -259,7 +259,7 @@ impl<T: ?Sized + MemDbgImpl> MemDbgImpl for Box<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.as_ref()._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -282,7 +282,7 @@ impl<P: MemDbgImpl> MemDbgImpl for core::pin::Pin<P> {
         is_last: bool,
         padded_size: usize,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         // SAFETY: `Pin<P>` is `#[repr(transparent)]` over `P`, so `&Pin<P>`
         // and `&P` have identical layout. Taking a shared reference to `P`
@@ -309,7 +309,7 @@ impl<P: MemDbgImpl> MemDbgImpl for core::pin::Pin<P> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         // SAFETY: see `_mem_dbg_depth_on` above.
         let pointer = unsafe { &*(self as *const core::pin::Pin<P> as *const P) };
@@ -406,7 +406,7 @@ macro_rules! impl_tuples_muncher {
                 prefix: &mut String,
                 _is_last: bool,
                 flags: DbgFlags,
-                dbg_refs: &mut HashSet<usize>,
+                dbg_refs: &mut BTreeSet<usize>,
             ) -> core::fmt::Result {
                 // Compute size of tuple minus one for last-field check.
                 let mut _max_idx = $idx;
@@ -534,7 +534,7 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::Range<Idx> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.start._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -554,7 +554,7 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeFrom<Idx> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.start._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -571,7 +571,7 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeInclusive<Idx> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.start()._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -591,7 +591,7 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeTo<Idx> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.end._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -608,7 +608,7 @@ impl<Idx: MemDbgImpl> MemDbgImpl for core::ops::RangeToInclusive<Idx> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.end._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -642,7 +642,7 @@ impl crate::MemSize for MutablyBorrowed {
     fn mem_size_rec(
         &self,
         _flags: crate::SizeFlags,
-        _refs: &mut crate::HashMap<usize, usize>,
+        _refs: &mut crate::BTreeMap<usize, usize>,
     ) -> usize {
         0
     }
@@ -659,7 +659,7 @@ impl MemDbgImpl for MutablyBorrowed {
         is_last: bool,
         padded_size: usize,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         // Suppress the type name so the output shows only "<mutably borrowed>".
         self._mem_dbg_depth_on_impl(
@@ -686,7 +686,7 @@ impl<T: MemDbgImpl> MemDbgImpl for core::cell::RefCell<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         if let Ok(borrow) = self.try_borrow() {
             borrow._mem_dbg_rec_on(
@@ -717,7 +717,7 @@ impl<T: MemDbgImpl> MemDbgImpl for core::cell::Cell<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         // SAFETY: we temporarily take a shared reference to the inner value;
         // since &self exists, &mut self cannot exist.
@@ -737,7 +737,7 @@ impl<T: MemDbgImpl> MemDbgImpl for core::cell::UnsafeCell<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         // SAFETY: we temporarily take a shared reference to the inner value; no
         // concurrent mutation through UnsafeCell::get() can occur during the
@@ -761,7 +761,7 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::Mutex<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -781,7 +781,7 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::RwLock<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.read()
             .unwrap_or_else(|e| e.into_inner())
@@ -800,7 +800,7 @@ impl<T: MemDbgImpl> MemDbgImpl for core::cell::OnceCell<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.get()._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -818,7 +818,7 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::MutexGuard<'_, T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         use core::ops::Deref;
         if flags.contains(DbgFlags::FOLLOW_REFS) {
@@ -841,7 +841,7 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::RwLockReadGuard<'_, T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         use core::ops::Deref;
         if flags.contains(DbgFlags::FOLLOW_REFS) {
@@ -864,7 +864,7 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::RwLockWriteGuard<'_, T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         use core::ops::Deref;
         if flags.contains(DbgFlags::FOLLOW_REFS) {
@@ -905,7 +905,7 @@ impl<T: MemDbgImpl + std::io::Read> MemDbgImpl for std::io::BufReader<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.get_ref()._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -923,7 +923,7 @@ impl<T: MemDbgImpl + std::io::Write> MemDbgImpl for std::io::BufWriter<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.get_ref()._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -941,7 +941,7 @@ impl<T: MemDbgImpl> MemDbgImpl for std::io::Cursor<T> {
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self.get_ref()._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
@@ -974,7 +974,7 @@ impl<A: maligned::Alignment, T: MemDbgImpl> MemDbgImpl for maligned::Aligned<A, 
         prefix: &mut String,
         is_last: bool,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         use core::ops::Deref;
         self.deref()._mem_dbg_rec_on(

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -483,6 +483,19 @@ impl<K: FlatType, V: FlatType> MemDbgImpl for std::collections::HashMap<K, V> wh
 {
 }
 
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType, S> MemDbgImpl for hashbrown::HashSet<K, S> where
+    hashbrown::HashSet<K, S>: crate::impl_mem_size::MemSizeHelper<<K as FlatType>::Flat>
+{
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType, V: FlatType, S> MemDbgImpl for hashbrown::HashMap<K, V, S> where
+    hashbrown::HashMap<K, V, S>:
+        crate::impl_mem_size::MemSizeHelper2<<K as FlatType>::Flat, <V as FlatType>::Flat>
+{
+}
+
 #[cfg(feature = "std")]
 impl<T: FlatType> MemDbgImpl for std::collections::BTreeSet<T> where
     std::collections::BTreeSet<T>: MemSizeHelper<<T as FlatType>::Flat>

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -13,7 +13,7 @@ use core::sync::atomic::*;
 #[cfg(feature = "std")]
 use core::ops::Deref;
 
-use crate::{Boolean, False, FlatType, HashMap, MemSize, SizeFlags, True};
+use crate::{BTreeMap, Boolean, False, FlatType, MemSize, SizeFlags, True};
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::VecDeque;
@@ -32,7 +32,7 @@ macro_rules! impl_size_of {
 
         impl MemSize for $ty {
             #[inline(always)]
-            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
                 core::mem::size_of::<Self>()
             }
         }
@@ -61,7 +61,7 @@ impl FlatType for str {
 }
 
 impl MemSize for str {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         self.len()
     }
 }
@@ -71,7 +71,7 @@ impl FlatType for String {
 }
 
 impl MemSize for String {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::CAPACITY) {
                 self.capacity()
@@ -88,7 +88,7 @@ impl<T: ?Sized> FlatType for PhantomData<T> {
 }
 
 impl<T: ?Sized> MemSize for PhantomData<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         0
     }
 }
@@ -100,7 +100,7 @@ impl<T: ?Sized + MemSize> FlatType for &'_ T {
 }
 
 impl<T: ?Sized + MemSize> MemSize for &'_ T {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         if flags.contains(SizeFlags::FOLLOW_REFS) {
             let ptr = *self as *const T as *const () as usize;
             if !refs.contains_key(&ptr) {
@@ -117,7 +117,7 @@ impl<T: ?Sized + MemSize> FlatType for &'_ mut T {
 }
 
 impl<T: ?Sized + MemSize> MemSize for &'_ mut T {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <&'_ T as MemSize>::mem_size_rec(&&**self, flags, refs)
     }
 }
@@ -130,7 +130,7 @@ impl<T: ?Sized> FlatType for *const T {
 }
 
 impl<T: ?Sized> MemSize for *const T {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -140,7 +140,7 @@ impl<T: ?Sized> FlatType for *mut T {
 }
 
 impl<T: ?Sized> MemSize for *mut T {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -152,7 +152,7 @@ impl<T: FlatType> FlatType for Option<T> {
 }
 
 impl<T: MemSize> MemSize for Option<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + self.as_ref().map_or(0, |x| {
                 <T as MemSize>::mem_size_rec(x, flags, refs) - core::mem::size_of::<T>()
@@ -167,7 +167,7 @@ impl<T: FlatType, E: FlatType> FlatType for Result<T, E> {
 }
 
 impl<T: MemSize, E: MemSize> MemSize for Result<T, E> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 Ok(t) => <T as MemSize>::mem_size_rec(t, flags, refs) - core::mem::size_of::<T>(),
@@ -183,7 +183,7 @@ impl<B: FlatType, C: FlatType> FlatType for core::ops::ControlFlow<B, C> {
 }
 
 impl<B: MemSize, C: MemSize> MemSize for core::ops::ControlFlow<B, C> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 core::ops::ControlFlow::Break(b) => {
@@ -201,7 +201,7 @@ impl<T: FlatType> FlatType for core::task::Poll<T> {
 }
 
 impl<T: MemSize> MemSize for core::task::Poll<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 core::task::Poll::Ready(t) => {
@@ -217,7 +217,7 @@ impl<T: FlatType> FlatType for core::ops::Bound<T> {
 }
 
 impl<T: MemSize> MemSize for core::ops::Bound<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 core::ops::Bound::Included(t) | core::ops::Bound::Excluded(t) => {
@@ -233,7 +233,7 @@ impl<T: FlatType> FlatType for core::cmp::Reverse<T> {
 }
 
 impl<T: MemSize> MemSize for core::cmp::Reverse<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() + <T as MemSize>::mem_size_rec(&self.0, flags, refs)
             - core::mem::size_of::<T>()
     }
@@ -246,7 +246,7 @@ impl<T: ?Sized> FlatType for Box<T> {
 }
 
 impl<T: ?Sized + MemSize> MemSize for Box<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() + <T as MemSize>::mem_size_rec(self.as_ref(), flags, refs)
     }
 }
@@ -258,7 +258,7 @@ impl<P: FlatType> FlatType for core::pin::Pin<P> {
 }
 
 impl<P: MemSize> MemSize for core::pin::Pin<P> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         // SAFETY: `Pin<P>` is `#[repr(transparent)]` over `P`, so `&Pin<P>`
         // and `&P` have identical layout. Taking a shared reference to `P`
         // does not move the pointee.
@@ -300,7 +300,7 @@ impl<T> FlatType for std::rc::Rc<T> {
 /// ```
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::rc::Rc<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         if flags.contains(SizeFlags::FOLLOW_RCS) {
             let ptr = std::rc::Rc::as_ptr(self) as usize;
             if !refs.contains_key(&ptr) {
@@ -325,7 +325,7 @@ impl<T: ?Sized> FlatType for std::rc::Weak<T> {
 
 #[cfg(feature = "std")]
 impl<T: ?Sized> MemSize for std::rc::Weak<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -364,7 +364,7 @@ struct ArcInner<T: ?Sized> {
 /// ```
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::Arc<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         if flags.contains(SizeFlags::FOLLOW_RCS) {
             let ptr = std::sync::Arc::as_ptr(self) as usize;
             if !refs.contains_key(&ptr) {
@@ -388,7 +388,7 @@ impl<T: ?Sized> FlatType for std::sync::Weak<T> {
 
 #[cfg(feature = "std")]
 impl<T: ?Sized> MemSize for std::sync::Weak<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -400,7 +400,7 @@ impl<T: ?Sized> MemSize for std::sync::Weak<T> {
 /// See [`crate::FlatType`] for more information.
 #[doc(hidden)]
 pub trait MemSizeHelper<T: Boolean> {
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize;
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize;
 }
 
 // Slices
@@ -413,21 +413,21 @@ impl<T: FlatType> MemSize for [T]
 where
     [T]: MemSizeHelper<<T as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <[T] as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(self, flags, refs)
     }
 }
 
 impl<T: FlatType + MemSize> MemSizeHelper<True> for [T] {
     #[inline(always)]
-    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of_val(self)
     }
 }
 
 impl<T: FlatType + MemSize> MemSizeHelper<False> for [T] {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         self.iter()
             .map(|x| <T as MemSize>::mem_size_rec(x, flags, refs))
             .sum::<usize>()
@@ -444,21 +444,21 @@ impl<T: FlatType, const N: usize> MemSize for [T; N]
 where
     [T; N]: MemSizeHelper<<T as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <[T; N] as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(self, flags, refs)
     }
 }
 
 impl<T: MemSize, const N: usize> MemSizeHelper<True> for [T; N] {
     #[inline(always)]
-    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
 
 impl<T: MemSize, const N: usize> MemSizeHelper<False> for [T; N] {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + self
                 .iter()
@@ -477,14 +477,14 @@ impl<T: FlatType> MemSize for Vec<T>
 where
     Vec<T>: MemSizeHelper<<T as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <Vec<T> as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(self, flags, refs)
     }
 }
 
 impl<T: FlatType + MemSize> MemSizeHelper<True> for Vec<T> {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::CAPACITY) {
                 self.capacity()
@@ -496,7 +496,7 @@ impl<T: FlatType + MemSize> MemSizeHelper<True> for Vec<T> {
 
 impl<T: FlatType + MemSize> MemSizeHelper<False> for Vec<T> {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + self
                 .iter()
@@ -520,14 +520,14 @@ impl<T: FlatType> MemSize for VecDeque<T>
 where
     VecDeque<T>: MemSizeHelper<<T as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <VecDeque<T> as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(self, flags, refs)
     }
 }
 
 impl<T: FlatType + MemSize> MemSizeHelper<True> for VecDeque<T> {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::CAPACITY) {
                 self.capacity()
@@ -539,7 +539,7 @@ impl<T: FlatType + MemSize> MemSizeHelper<True> for VecDeque<T> {
 
 impl<T: FlatType + MemSize> MemSizeHelper<False> for VecDeque<T> {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + self
                 .iter()
@@ -583,7 +583,7 @@ macro_rules! impl_tuples_muncher {
         }
 
         impl<$ty: MemSize, $($nty: MemSize,)*> MemSize for ($ty, $($nty,)*) {
-            fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+            fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
                 let mut bytes = ::core::mem::size_of::<Self>();
                 bytes += <$ty as MemSize>::mem_size_rec(&self.$idx, flags, refs) - ::core::mem::size_of::<$ty>();
                 $( bytes += <$nty as MemSize>::mem_size_rec(&self.$nidx, flags, refs) - ::core::mem::size_of::<$nty>(); )*
@@ -596,7 +596,7 @@ macro_rules! impl_tuples_muncher {
         }
 
         impl<$ty, $($nty,)* R> MemSize for fn($ty, $($nty,)*) -> R {
-            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
                 ::core::mem::size_of::<Self>()
             }
         }
@@ -623,7 +623,7 @@ impl<R> FlatType for fn() -> R {
 }
 
 impl<R> MemSize for fn() -> R {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -635,7 +635,7 @@ impl<Idx: FlatType> FlatType for core::ops::Range<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::Range<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + <Idx as MemSize>::mem_size_rec(&self.start, flags, refs)
             + <Idx as MemSize>::mem_size_rec(&self.end, flags, refs)
@@ -648,7 +648,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeFrom<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeFrom<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size_rec(&self.start, flags, refs)
             - core::mem::size_of::<Idx>()
     }
@@ -659,7 +659,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeInclusive<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeInclusive<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + <Idx as MemSize>::mem_size_rec(self.start(), flags, refs)
             + <Idx as MemSize>::mem_size_rec(self.end(), flags, refs)
@@ -672,7 +672,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeTo<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeTo<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size_rec(&self.end, flags, refs)
             - core::mem::size_of::<Idx>()
     }
@@ -683,7 +683,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeToInclusive<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeToInclusive<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size_rec(&self.end, flags, refs)
             - core::mem::size_of::<Idx>()
     }
@@ -705,7 +705,7 @@ impl<T: FlatType> FlatType for core::cell::RefCell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::RefCell<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         if let Ok(borrow) = self.try_borrow() {
             core::mem::size_of::<Self>() - core::mem::size_of::<T>()
                 + <T as MemSize>::mem_size_rec(&*borrow, flags, refs)
@@ -721,7 +721,7 @@ impl<T: FlatType> FlatType for core::cell::Cell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::Cell<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         // SAFETY: we temporarily take a shared reference to the inner value;
         // since &self exists, &mut self cannot exist.
         let borrow = unsafe { &*self.as_ptr() };
@@ -734,7 +734,7 @@ impl<T: FlatType> FlatType for core::cell::OnceCell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::OnceCell<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         let mut size = core::mem::size_of::<Self>();
         if let Some(t) = self.get() {
             size += <T as MemSize>::mem_size_rec(t, flags, refs) - core::mem::size_of::<T>();
@@ -748,7 +748,7 @@ impl<T: FlatType> FlatType for core::cell::UnsafeCell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::UnsafeCell<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         // SAFETY: we temporarily take a shared reference to the inner value; no
         // concurrent mutation through UnsafeCell::get() can occur during the
         // temporary borrow.
@@ -766,7 +766,7 @@ impl<T: FlatType> FlatType for std::sync::Mutex<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::Mutex<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         // Use unwrap_or_else to handle poisoned mutexes gracefully
         let guard = self.lock().unwrap_or_else(|e| e.into_inner());
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
@@ -781,7 +781,7 @@ impl<T: FlatType> FlatType for std::sync::RwLock<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::RwLock<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         // Use unwrap_or_else to handle poisoned locks gracefully
         let guard = self.read().unwrap_or_else(|e| e.into_inner());
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
@@ -798,7 +798,7 @@ impl<T: MemSize> MemSize for std::sync::RwLock<T> {
 /// * `flags` - The SizeFlags to use for the computation.
 #[cfg(feature = "std")]
 #[inline(always)]
-fn deref_pointer_size<M>(obj: &M, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize
+fn deref_pointer_size<M>(obj: &M, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize
 where
     M: Deref<Target: MemSize + Sized>,
 {
@@ -818,7 +818,7 @@ impl<T> FlatType for std::sync::MutexGuard<'_, T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::MutexGuard<'_, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         deref_pointer_size(self, flags, refs)
     }
 }
@@ -830,7 +830,7 @@ impl<T> FlatType for std::sync::RwLockReadGuard<'_, T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::RwLockReadGuard<'_, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         deref_pointer_size(self, flags, refs)
     }
 }
@@ -842,7 +842,7 @@ impl<T> FlatType for std::sync::RwLockWriteGuard<'_, T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::RwLockWriteGuard<'_, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         deref_pointer_size(self, flags, refs)
     }
 }
@@ -856,7 +856,7 @@ impl FlatType for std::path::Path {
 
 #[cfg(feature = "std")]
 impl MemSize for std::path::Path {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <std::ffi::OsStr as MemSize>::mem_size_rec(self.as_os_str(), flags, refs)
     }
 }
@@ -868,7 +868,7 @@ impl FlatType for std::path::PathBuf {
 
 #[cfg(feature = "std")]
 impl MemSize for std::path::PathBuf {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::CAPACITY) {
                 self.capacity()
@@ -885,7 +885,7 @@ impl FlatType for std::ffi::OsStr {
 
 #[cfg(feature = "std")]
 impl MemSize for std::ffi::OsStr {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         self.as_encoded_bytes().len()
     }
 }
@@ -897,7 +897,7 @@ impl FlatType for std::ffi::OsString {
 
 #[cfg(feature = "std")]
 impl MemSize for std::ffi::OsString {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         // OsString is like String - it has heap-allocated data
         // We use len() by default, and capacity() with CAPACITY flag
         core::mem::size_of::<Self>()
@@ -928,7 +928,7 @@ impl<T> FlatType for std::io::BufReader<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize + std::io::Read> MemSize for std::io::BufReader<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + self.capacity()
             + <T as MemSize>::mem_size_rec(self.get_ref(), flags, refs)
@@ -942,7 +942,7 @@ impl<T: std::io::Write> FlatType for std::io::BufWriter<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize + std::io::Write> MemSize for std::io::BufWriter<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + self.capacity()
             + <T as MemSize>::mem_size_rec(self.get_ref(), flags, refs)
@@ -956,7 +956,7 @@ impl<T> FlatType for std::io::Cursor<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::io::Cursor<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + <T as MemSize>::mem_size_rec(self.get_ref(), flags, refs)
     }
@@ -991,7 +991,7 @@ impl FlatType for mmap_rs::Mmap {
 
 #[cfg(feature = "mmap-rs")]
 impl MemSize for mmap_rs::Mmap {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::FOLLOW_REFS) {
                 self.len()
@@ -1008,7 +1008,7 @@ impl FlatType for mmap_rs::MmapMut {
 
 #[cfg(feature = "mmap-rs")]
 impl MemSize for mmap_rs::MmapMut {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::FOLLOW_REFS) {
                 self.len()
@@ -1076,7 +1076,7 @@ impl<T: FlatType> MemSize for std::collections::HashSet<T>
 where
     std::collections::HashSet<T>: MemSizeHelper<<T as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <std::collections::HashSet<T> as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(
             self, flags, refs,
         )
@@ -1108,7 +1108,7 @@ fn fix_set_for_capacity<K>(
 #[cfg(feature = "std")]
 impl<K: FlatType + MemSize> MemSizeHelper<True> for std::collections::HashSet<K> {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         fix_set_for_capacity(self, core::mem::size_of::<K>() * self.len(), flags)
     }
 }
@@ -1116,7 +1116,7 @@ impl<K: FlatType + MemSize> MemSizeHelper<True> for std::collections::HashSet<K>
 #[cfg(feature = "std")]
 impl<K: FlatType + MemSize> MemSizeHelper<False> for std::collections::HashSet<K> {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         fix_set_for_capacity(
             self,
             self.iter()
@@ -1135,7 +1135,7 @@ impl<K: FlatType + MemSize> MemSizeHelper<False> for std::collections::HashSet<K
 /// See [`crate::FlatType`] for more information.
 #[doc(hidden)]
 pub trait MemSizeHelper2<K: Boolean, V: Boolean> {
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize;
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize;
 }
 
 #[cfg(feature = "std")]
@@ -1148,7 +1148,7 @@ impl<K: FlatType, V: FlatType> MemSize for std::collections::HashMap<K, V>
 where
     std::collections::HashMap<K, V>: MemSizeHelper2<<K as FlatType>::Flat, <V as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <std::collections::HashMap<K, V> as MemSizeHelper2<
             <K as FlatType>::Flat,
             <V as FlatType>::Flat,
@@ -1183,7 +1183,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<True, True>
     for std::collections::HashMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         fix_map_for_capacity(
             self,
             (core::mem::size_of::<K>() + core::mem::size_of::<V>()) * self.len(),
@@ -1197,7 +1197,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<True, False>
     for std::collections::HashMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         fix_map_for_capacity(
             self,
             (core::mem::size_of::<K>()) * self.len()
@@ -1215,7 +1215,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<False, True>
     for std::collections::HashMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         fix_map_for_capacity(
             self,
             self.keys()
@@ -1232,7 +1232,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<False, False>
     for std::collections::HashMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         fix_map_for_capacity(
             self,
             self.iter()
@@ -1324,7 +1324,7 @@ impl<T: FlatType> MemSize for std::collections::BTreeSet<T>
 where
     std::collections::BTreeSet<T>: MemSizeHelper<<T as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <std::collections::BTreeSet<T> as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(
             self, flags, refs,
         )
@@ -1334,7 +1334,7 @@ where
 #[cfg(feature = "std")]
 impl<T: FlatType + MemSize> MemSizeHelper<True> for std::collections::BTreeSet<T> {
     #[inline(always)]
-    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<std::collections::BTreeSet<T>>()
             + estimate_btree_size::<T, ()>(self.len(), 0)
     }
@@ -1343,7 +1343,7 @@ impl<T: FlatType + MemSize> MemSizeHelper<True> for std::collections::BTreeSet<T
 #[cfg(feature = "std")]
 impl<T: FlatType + MemSize> MemSizeHelper<False> for std::collections::BTreeSet<T> {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<std::collections::BTreeSet<T>>()
             + estimate_btree_size::<T, ()>(
                 self.len(),
@@ -1366,7 +1366,7 @@ impl<K: FlatType, V: FlatType> MemSize for std::collections::BTreeMap<K, V>
 where
     std::collections::BTreeMap<K, V>: MemSizeHelper2<<K as FlatType>::Flat, <V as FlatType>::Flat>,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         <std::collections::BTreeMap<K, V> as MemSizeHelper2<
             <K as FlatType>::Flat,
             <V as FlatType>::Flat,
@@ -1379,7 +1379,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<True, True>
     for std::collections::BTreeMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<std::collections::BTreeMap<K, V>>()
             + estimate_btree_size::<K, V>(self.len(), 0)
     }
@@ -1390,7 +1390,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<True, False>
     for std::collections::BTreeMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<std::collections::BTreeMap<K, V>>()
             + estimate_btree_size::<K, V>(
                 self.len(),
@@ -1408,7 +1408,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<False, True>
     for std::collections::BTreeMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<std::collections::BTreeMap<K, V>>()
             + estimate_btree_size::<K, V>(
                 self.len(),
@@ -1426,7 +1426,7 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<False, False>
     for std::collections::BTreeMap<K, V>
 {
     #[inline(always)]
-    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<std::collections::BTreeMap<K, V>>()
             + estimate_btree_size::<K, V>(
                 self.len(),
@@ -1447,7 +1447,7 @@ impl<H> FlatType for core::hash::BuildHasherDefault<H> {
     type Flat = True;
 }
 impl<H> MemSize for core::hash::BuildHasherDefault<H> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         // it's a phantom hash
         debug_assert_eq!(core::mem::size_of::<Self>(), 0);
         0
@@ -1463,7 +1463,7 @@ impl FlatType for std::hash::DefaultHasher {
 // This implementation assumes that DefaultHasher is a fixed-size type
 // that does not allocate memory on the heap.
 impl MemSize for std::hash::DefaultHasher {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -1475,7 +1475,7 @@ impl FlatType for std::collections::hash_map::RandomState {
 
 #[cfg(feature = "std")]
 impl MemSize for std::collections::hash_map::RandomState {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -1489,7 +1489,7 @@ impl<T: ?Sized> FlatType for core::ptr::NonNull<T> {
 }
 
 impl<T: ?Sized> MemSize for core::ptr::NonNull<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -1516,7 +1516,7 @@ impl<A: maligned::Alignment, T: MemSize + FlatType> FlatType for maligned::Align
 
 #[cfg(feature = "maligned")]
 impl<A: maligned::Alignment, T: MemSize> MemSize for maligned::Aligned<A, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
         use core::ops::Deref;
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + <T as MemSize>::mem_size_rec(self.deref(), flags, refs)

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1026,21 +1026,21 @@ impl MemSize for mmap_rs::MmapMut {
 // Group width for Swiss Tables (hashbrown). This depends on SIMD support:
 // - x86/x86_64 with SSE2: 16 bytes
 // - Other platforms (ARM64 NEON, generic): 8 bytes
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 #[cfg(all(
     any(target_arch = "x86_64", target_arch = "x86"),
     any(target_feature = "sse2", target_env = "msvc")
 ))]
 const GROUP_WIDTH: usize = 16;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 #[cfg(not(all(
     any(target_arch = "x86_64", target_arch = "x86"),
     any(target_feature = "sse2", target_env = "msvc")
 )))]
 const GROUP_WIDTH: usize = 8;
 
-// Straight from hashbrown
-#[cfg(feature = "std")]
+// Straight from hashbrown.
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 fn capacity_to_buckets(cap: usize) -> Option<usize> {
     if cap == 0 {
         return Some(0);
@@ -1083,24 +1083,30 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 // Add to the given size the space occupied on the stack by the hash set, by the unused
 // but unavoidable buckets, by the speedup bytes of Swiss Tables, and if `flags` contains
 // `SizeFlags::CAPACITY`, by empty buckets.
+//
+// `type_size` is the stack size of the wrapping container, `len` and `capacity` come
+// from the actual collection. Lifted out of the std-only impl so the same helper can
+// service both `std::collections::HashSet` and `hashbrown::HashSet`.
 fn fix_set_for_capacity<K>(
-    hash_set: &std::collections::HashSet<K>,
-    size: usize,
+    type_size: usize,
+    len: usize,
+    capacity: usize,
+    items_size: usize,
     flags: SizeFlags,
 ) -> usize {
     let capacity = if flags.contains(SizeFlags::CAPACITY) {
-        hash_set.capacity()
+        capacity
     } else {
-        hash_set.len()
+        len
     };
     let buckets = capacity_to_buckets(capacity).unwrap_or(usize::MAX);
-    core::mem::size_of::<std::collections::HashSet<K>>()
-        + size
-        + (buckets - hash_set.len()) * core::mem::size_of::<K>()
+    type_size
+        + items_size
+        + (buckets - len) * core::mem::size_of::<K>()
         + buckets * core::mem::size_of::<u8>()
         + if buckets > 0 { GROUP_WIDTH } else { 0 }
 }
@@ -1109,7 +1115,13 @@ fn fix_set_for_capacity<K>(
 impl<K: FlatType + MemSize> MemSizeHelper<True> for std::collections::HashSet<K> {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
-        fix_set_for_capacity(self, core::mem::size_of::<K>() * self.len(), flags)
+        fix_set_for_capacity::<K>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
+            core::mem::size_of::<K>() * self.len(),
+            flags,
+        )
     }
 }
 
@@ -1117,8 +1129,10 @@ impl<K: FlatType + MemSize> MemSizeHelper<True> for std::collections::HashSet<K>
 impl<K: FlatType + MemSize> MemSizeHelper<False> for std::collections::HashSet<K> {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
-        fix_set_for_capacity(
-            self,
+        fix_set_for_capacity::<K>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
             self.iter()
                 .map(|x| <K as MemSize>::mem_size_rec(x, flags, refs))
                 .sum::<usize>(),
@@ -1127,7 +1141,7 @@ impl<K: FlatType + MemSize> MemSizeHelper<False> for std::collections::HashSet<K
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 /// A helper trait that makes it possible to implement differently
 /// the size computation for maps in which keys or values are
 /// flat types.
@@ -1156,24 +1170,29 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 // Add to the given size the space occupied on the stack by the hash map, by the unused
 // but unavoidable buckets, by the speedup bytes of Swiss Tables, and if `flags` contains
 // `SizeFlags::CAPACITY`, by empty buckets.
+//
+// See [`fix_set_for_capacity`] for why `type_size`/`len`/`capacity` are passed in
+// rather than a typed reference.
 fn fix_map_for_capacity<K, V>(
-    hash_map: &std::collections::HashMap<K, V>,
-    size: usize,
+    type_size: usize,
+    len: usize,
+    capacity: usize,
+    items_size: usize,
     flags: SizeFlags,
 ) -> usize {
     let capacity = if flags.contains(SizeFlags::CAPACITY) {
-        hash_map.capacity()
+        capacity
     } else {
-        hash_map.len()
+        len
     };
     let buckets = capacity_to_buckets(capacity).unwrap_or(usize::MAX);
-    core::mem::size_of::<std::collections::HashMap<K, V>>()
-        + size
-        + (buckets - hash_map.len()) * (core::mem::size_of::<K>() + core::mem::size_of::<V>())
+    type_size
+        + items_size
+        + (buckets - len) * (core::mem::size_of::<K>() + core::mem::size_of::<V>())
         + buckets * core::mem::size_of::<u8>()
         + if buckets > 0 { GROUP_WIDTH } else { 0 }
 }
@@ -1184,8 +1203,10 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<True, True>
 {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
-        fix_map_for_capacity(
-            self,
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
             (core::mem::size_of::<K>() + core::mem::size_of::<V>()) * self.len(),
             flags,
         )
@@ -1198,8 +1219,10 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<True, False>
 {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
-        fix_map_for_capacity(
-            self,
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
             (core::mem::size_of::<K>()) * self.len()
                 + self
                     .values()
@@ -1216,8 +1239,10 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<False, True>
 {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
-        fix_map_for_capacity(
-            self,
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
             self.keys()
                 .map(|k| <K as MemSize>::mem_size_rec(k, flags, refs))
                 .sum::<usize>()
@@ -1233,8 +1258,160 @@ impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSizeHelper2<False, False>
 {
     #[inline(always)]
     fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
-        fix_map_for_capacity(
-            self,
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
+            self.iter()
+                .map(|(k, v)| {
+                    <K as MemSize>::mem_size_rec(k, flags, refs)
+                        + <V as MemSize>::mem_size_rec(v, flags, refs)
+                })
+                .sum::<usize>(),
+            flags,
+        )
+    }
+}
+
+// Hash-based containers from the `hashbrown` crate. Mirrors the `std::collections`
+// impls above; uses the same Swiss-table layout math (`capacity_to_buckets`,
+// `GROUP_WIDTH`) since both ride on hashbrown internally.
+//
+// Hasher `S` is left unbounded: the hasher state is owned inline by the table and
+// its size is already accounted for via `core::mem::size_of::<HashMap<K, V, S>>`.
+// If `S` heap-allocates (unusual) this undercounts — match the std impl behaviour
+// rather than forcing every user to derive `MemSize` on their hasher.
+
+#[cfg(feature = "hashbrown")]
+impl<T, S> FlatType for hashbrown::HashSet<T, S> {
+    type Flat = False;
+}
+
+#[cfg(feature = "hashbrown")]
+impl<T: FlatType, S> MemSize for hashbrown::HashSet<T, S>
+where
+    hashbrown::HashSet<T, S>: MemSizeHelper<<T as FlatType>::Flat>,
+{
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
+        <hashbrown::HashSet<T, S> as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(
+            self, flags, refs,
+        )
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType + MemSize, S> MemSizeHelper<True> for hashbrown::HashSet<K, S> {
+    #[inline(always)]
+    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
+        fix_set_for_capacity::<K>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
+            core::mem::size_of::<K>() * self.len(),
+            flags,
+        )
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType + MemSize, S> MemSizeHelper<False> for hashbrown::HashSet<K, S> {
+    #[inline(always)]
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
+        fix_set_for_capacity::<K>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
+            self.iter()
+                .map(|x| <K as MemSize>::mem_size_rec(x, flags, refs))
+                .sum::<usize>(),
+            flags,
+        )
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K, V, S> FlatType for hashbrown::HashMap<K, V, S> {
+    type Flat = False;
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType, V: FlatType, S> MemSize for hashbrown::HashMap<K, V, S>
+where
+    hashbrown::HashMap<K, V, S>: MemSizeHelper2<<K as FlatType>::Flat, <V as FlatType>::Flat>,
+{
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
+        <hashbrown::HashMap<K, V, S> as MemSizeHelper2<
+            <K as FlatType>::Flat,
+            <V as FlatType>::Flat,
+        >>::mem_size_impl(self, flags, refs)
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType + MemSize, V: FlatType + MemSize, S> MemSizeHelper2<True, True>
+    for hashbrown::HashMap<K, V, S>
+{
+    #[inline(always)]
+    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut BTreeMap<usize, usize>) -> usize {
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
+            (core::mem::size_of::<K>() + core::mem::size_of::<V>()) * self.len(),
+            flags,
+        )
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType + MemSize, V: FlatType + MemSize, S> MemSizeHelper2<True, False>
+    for hashbrown::HashMap<K, V, S>
+{
+    #[inline(always)]
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
+            (core::mem::size_of::<K>()) * self.len()
+                + self
+                    .values()
+                    .map(|v| <V as MemSize>::mem_size_rec(v, flags, refs))
+                    .sum::<usize>(),
+            flags,
+        )
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType + MemSize, V: FlatType + MemSize, S> MemSizeHelper2<False, True>
+    for hashbrown::HashMap<K, V, S>
+{
+    #[inline(always)]
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
+            self.keys()
+                .map(|k| <K as MemSize>::mem_size_rec(k, flags, refs))
+                .sum::<usize>()
+                + (core::mem::size_of::<V>()) * self.len(),
+            flags,
+        )
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K: FlatType + MemSize, V: FlatType + MemSize, S> MemSizeHelper2<False, False>
+    for hashbrown::HashMap<K, V, S>
+{
+    #[inline(always)]
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize {
+        fix_map_for_capacity::<K, V>(
+            core::mem::size_of::<Self>(),
+            self.len(),
+            self.capacity(),
             self.iter()
                 .map(|(k, v)| {
                     <K as MemSize>::mem_size_rec(k, flags, refs)

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -8,18 +8,23 @@
 #![doc = include_str!("../README.md")]
 #![deny(unconditional_recursion)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 
-/// Hash map for pointer deduplication in mem_size (re-exported for derive macro).
+/// Map for pointer deduplication in `mem_size` (re-exported for the derive macro).
+///
+/// We use [`alloc::collections::BTreeMap`] rather than `std::collections::HashMap`
+/// or `hashbrown::HashMap` so the type is available without the `std` feature
+/// and without pulling an external dependency. The dedup set is small (one
+/// entry per unique pointer reached during the walk) and `usize` keys make
+/// `BTreeMap`'s O(log n) ops effectively free for any realistic use.
 #[doc(hidden)]
-pub use hashbrown::HashMap;
-/// Hash set for pointer deduplication in mem_dbg.
+pub use alloc::collections::BTreeMap;
+/// Set for pointer deduplication in `mem_dbg`. See [`BTreeMap`] for rationale.
 #[doc(hidden)]
-pub use hashbrown::HashSet;
+pub use alloc::collections::BTreeSet;
 
 #[cfg(feature = "derive")]
 pub use mem_dbg_derive::{MemDbg, MemSize};
@@ -181,7 +186,7 @@ pub trait MemSize {
     /// Returns the (recursively computed) overall memory size of the structure
     /// in bytes.
     fn mem_size(&self, flags: SizeFlags) -> usize {
-        let mut refs = HashMap::new();
+        let mut refs = BTreeMap::new();
         let base = self.mem_size_rec(flags, &mut refs);
         base + refs.into_values().sum::<usize>()
     }
@@ -197,7 +202,7 @@ pub trait MemSize {
     /// contain references can simply ignore the `refs` parameter; otherwise,
     /// please have a look at the [implementation for
     /// references](#impl-MemSize-for-%26T).
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize;
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut BTreeMap<usize, usize>) -> usize;
 }
 
 bitflags::bitflags! {
@@ -273,7 +278,7 @@ pub trait MemDbg: MemDbgImpl {
     /// Writes to a [`core::fmt::Write`] debug info about the structure memory
     /// usage, expanding all levels of nested structures.
     fn mem_dbg_on(&self, writer: &mut impl core::fmt::Write, flags: DbgFlags) -> core::fmt::Result {
-        let mut dbg_refs = HashSet::new();
+        let mut dbg_refs = BTreeSet::new();
         self._mem_dbg_depth_on(
             writer,
             <Self as MemSize>::mem_size(self, flags.to_size_flags()),
@@ -309,7 +314,7 @@ pub trait MemDbg: MemDbgImpl {
         max_depth: usize,
         flags: DbgFlags,
     ) -> core::fmt::Result {
-        let mut dbg_refs = HashSet::new();
+        let mut dbg_refs = BTreeSet::new();
         self._mem_dbg_depth_on(
             writer,
             <Self as MemSize>::mem_size(self, flags.to_size_flags()),
@@ -347,7 +352,7 @@ pub trait MemDbgImpl: MemSize {
         _prefix: &mut String,
         _is_last: bool,
         _flags: DbgFlags,
-        _dbg_refs: &mut HashSet<usize>,
+        _dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         Ok(())
     }
@@ -373,7 +378,7 @@ pub trait MemDbgImpl: MemSize {
                     .map(|_| ())
             }
         }
-        let mut dbg_refs = HashSet::new();
+        let mut dbg_refs = BTreeSet::new();
         self._mem_dbg_depth_on(
             &mut Wrapper(std::io::stderr()),
             total_size,
@@ -397,7 +402,7 @@ pub trait MemDbgImpl: MemSize {
         is_last: bool,
         padded_size: usize,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
     ) -> core::fmt::Result {
         self._mem_dbg_depth_on_impl(
             writer,
@@ -430,7 +435,7 @@ pub trait MemDbgImpl: MemSize {
         is_last: bool,
         padded_size: usize,
         flags: DbgFlags,
-        dbg_refs: &mut HashSet<usize>,
+        dbg_refs: &mut BTreeSet<usize>,
         ref_display: RefDisplay,
     ) -> core::fmt::Result {
         // Each depth level adds 2 characters to prefix ("│ " or "  ")

--- a/mem_dbg/tests/test_hashbrown_collections.rs
+++ b/mem_dbg/tests/test_hashbrown_collections.rs
@@ -1,0 +1,151 @@
+#![cfg(feature = "hashbrown")]
+
+//! Size assertions for `hashbrown::HashSet<T>` and `hashbrown::HashMap<K, V>`.
+//!
+//! Mirror of `test_hash_collections.rs` for the optional `hashbrown` feature.
+//! The `MemSize` implementation rides on the same Swiss-table layout math
+//! (`capacity_to_buckets` + `GROUP_WIDTH`); here we replicate the formula and
+//! assert agreement, exactly like the std variant.
+//!
+//! End-to-end agreement against the runtime allocator is exercised by
+//! `test_correctness.rs` for the std collections; the hashbrown impls share
+//! the same arithmetic so a separate cap-based test isn't needed.
+
+use hashbrown::{HashMap, HashSet};
+use mem_dbg::*;
+
+// Mirror of the constants in impl_mem_size.rs. GROUP_WIDTH is 16 for SSE2/NEON
+// targets and 8 elsewhere.
+#[cfg(any(
+    target_feature = "sse2",
+    all(target_arch = "aarch64", target_feature = "neon"),
+))]
+const GROUP_WIDTH: usize = 16;
+#[cfg(not(any(
+    target_feature = "sse2",
+    all(target_arch = "aarch64", target_feature = "neon"),
+)))]
+const GROUP_WIDTH: usize = 8;
+
+fn capacity_to_buckets(cap: usize) -> Option<usize> {
+    if cap == 0 {
+        return Some(0);
+    }
+    if cap < 8 {
+        return Some(if cap < 4 { 4 } else { 8 });
+    }
+    let adjusted_cap = cap.checked_mul(8)? / 7;
+    Some(adjusted_cap.next_power_of_two())
+}
+
+fn predicted_set_size<K, S>(set: &HashSet<K, S>, flags: SizeFlags, items_size: usize) -> usize {
+    let cap = if flags.contains(SizeFlags::CAPACITY) {
+        set.capacity()
+    } else {
+        set.len()
+    };
+    let buckets = capacity_to_buckets(cap).unwrap_or(usize::MAX);
+    core::mem::size_of::<HashSet<K, S>>()
+        + items_size
+        + (buckets - set.len()) * core::mem::size_of::<K>()
+        + buckets * core::mem::size_of::<u8>()
+        + if buckets > 0 { GROUP_WIDTH } else { 0 }
+}
+
+fn predicted_map_size<K, V, S>(
+    map: &HashMap<K, V, S>,
+    flags: SizeFlags,
+    items_size: usize,
+) -> usize {
+    let cap = if flags.contains(SizeFlags::CAPACITY) {
+        map.capacity()
+    } else {
+        map.len()
+    };
+    let buckets = capacity_to_buckets(cap).unwrap_or(usize::MAX);
+    core::mem::size_of::<HashMap<K, V, S>>()
+        + items_size
+        + (buckets - map.len()) * (core::mem::size_of::<K>() + core::mem::size_of::<V>())
+        + buckets * core::mem::size_of::<u8>()
+        + if buckets > 0 { GROUP_WIDTH } else { 0 }
+}
+
+#[test]
+fn test_empty_hashset() {
+    let set: HashSet<u32> = HashSet::new();
+    assert_eq!(
+        set.mem_size(SizeFlags::default()),
+        core::mem::size_of::<HashSet<u32>>()
+    );
+}
+
+#[test]
+fn test_empty_hashmap() {
+    let map: HashMap<u32, u32> = HashMap::new();
+    assert_eq!(
+        map.mem_size(SizeFlags::default()),
+        core::mem::size_of::<HashMap<u32, u32>>()
+    );
+}
+
+#[test]
+fn test_hashset_flat_keys() {
+    let set: HashSet<u32> = (0..32).collect();
+    let item_size = core::mem::size_of::<u32>() * set.len();
+    assert_eq!(
+        set.mem_size(SizeFlags::default()),
+        predicted_set_size(&set, SizeFlags::default(), item_size)
+    );
+    assert_eq!(
+        set.mem_size(SizeFlags::CAPACITY),
+        predicted_set_size(&set, SizeFlags::CAPACITY, item_size)
+    );
+}
+
+#[test]
+fn test_hashset_string_keys() {
+    let set: HashSet<alloc::string::String> = (0..16).map(|x| x.to_string()).collect();
+    let item_size: usize = set
+        .iter()
+        .map(|s| <alloc::string::String as MemSize>::mem_size(s, SizeFlags::default()))
+        .sum();
+    assert_eq!(
+        set.mem_size(SizeFlags::default()),
+        predicted_set_size(&set, SizeFlags::default(), item_size)
+    );
+}
+
+#[test]
+fn test_hashmap_flat_keys_and_values() {
+    let map: HashMap<u32, u64> = (0..32).map(|x| (x, x as u64)).collect();
+    let item_size = (core::mem::size_of::<u32>() + core::mem::size_of::<u64>()) * map.len();
+    assert_eq!(
+        map.mem_size(SizeFlags::default()),
+        predicted_map_size(&map, SizeFlags::default(), item_size)
+    );
+    assert_eq!(
+        map.mem_size(SizeFlags::CAPACITY),
+        predicted_map_size(&map, SizeFlags::CAPACITY, item_size)
+    );
+}
+
+#[test]
+fn test_hashmap_string_keys() {
+    let map: HashMap<alloc::string::String, u32> =
+        (0..16).map(|x| (x.to_string(), x as u32)).collect();
+    let item_size: usize = map
+        .iter()
+        .map(|(k, v)| {
+            <alloc::string::String as MemSize>::mem_size(k, SizeFlags::default())
+                + <u32 as MemSize>::mem_size(v, SizeFlags::default())
+                - core::mem::size_of::<u32>()
+        })
+        .sum::<usize>()
+        + core::mem::size_of::<u32>() * map.len();
+    assert_eq!(
+        map.mem_size(SizeFlags::default()),
+        predicted_map_size(&map, SizeFlags::default(), item_size)
+    );
+}
+
+extern crate alloc;


### PR DESCRIPTION
Drops the `hashbrown` direct dependency. The pointer-dedup containers used internally by `MemSize::mem_size_rec` and `MemDbgImpl::_mem_dbg_rec_on` are now `alloc::collections::BTreeMap<usize, usize>` and `alloc::collections::BTreeSet<usize>`.

## Why

The trait method signature

```rust
pub trait MemSize {
    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize;
                                                  //  ^^^^^^^ hashbrown::HashMap
}
```

leaks `hashbrown::HashMap` through mem_dbg's public API, even though the re-export is `#[doc(hidden)]`. Practical consequence: **every hashbrown major version bump is a SemVer-breaking change for mem_dbg**, which is why we are pinned to `hashbrown = "0.16"` with 0.17 already out (since 2026-04-06). Each future bump would force a mem_dbg breaking release just to follow the dep.

The original justification (PR #32 discussion, [comment](https://github.com/zommiommy/mem_dbg-rs/pull/32#issuecomment-3765707697)) was "stdlib already includes hashbrown, so we won't compile it twice". This is incorrect:

- std's hashbrown lives in `liballoc`, marked `rustc-private`, not exposed to Cargo.
- Our `hashbrown = "0.16"` dep is a separate compilation unit. Cargo.lock currently resolves three versions of hashbrown (0.15.5, 0.16.1, 0.17.0) from transitive deps; `mem_dbg` itself sits on 0.16.1.
- They do not dedupe; the binary contains both std's internal hashbrown and our 0.16.

## What changes

| | Before | After |
|---|---|---|
| Dedup map type | `hashbrown::HashMap<usize, usize>` | `alloc::collections::BTreeMap<usize, usize>` |
| Dedup set type | `hashbrown::HashSet<usize>` | `alloc::collections::BTreeSet<usize>` |
| Re-exports | `mem_dbg::HashMap` / `HashSet` | `mem_dbg::BTreeMap` / `BTreeSet` |
| `Cargo.toml` | `hashbrown = "0.16"` | (removed) |
| `extern crate alloc` | `#[cfg(not(feature = "std"))]` | unconditional |

## What does NOT change

The `MemSize` impl for `std::collections::HashMap` / `HashSet` (the layout-prediction code at `impl_mem_size.rs:1026+`, `GROUP_WIDTH`, `capacity_to_buckets`) is **unchanged**. That coupling is to std's internal hashbrown (whatever rustc shipped), not to our direct dep, so dropping the dep does not affect it. This is the same coupling [#41](https://github.com/zommiommy/mem_dbg-rs/pull/41) tightened for aarch64+NEON.

## Why this is safe

The dedup containers are used only for these operations:

- `.insert(ptr, size)` / `.insert(ptr)`
- `.contains_key(&ptr)` / `.contains(&ptr)`
- `.into_values().sum()`

All have direct `BTreeMap` / `BTreeSet` equivalents. The dedup set is small (one entry per unique heap-owning pointer reached during the walk) and the keys are `usize`, so swapping O(1) hashing for O(log n) integer comparisons is effectively free in practice.

## SemVer impact

Breaking change for users with **hand-written** `MemSize` or `MemDbgImpl` implementations that name the parameter type as `&mut HashMap<usize, usize>` / `&mut HashSet<usize>` (the previous re-exports). They need to rename to `BTreeMap<usize, usize>` / `BTreeSet<usize>`.

`#[derive(MemSize, MemDbg)]` users are unaffected — the macro emits the new types automatically.

## Verification

Host (x86_64):

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo clippy --features std,derive,half,maligned,mmap-rs,rand -- -D warnings`
- `cargo test --features std,derive,half,maligned,mmap-rs,rand` (including `test_all_types_mem_dbg_insta`)
- `cargo test --no-default-features -- --skip _snapshot`
- `cargo test --no-default-features --features derive -- --skip _snapshot`
- `cargo test --release --features std,derive --test test_correctness` (cap allocator)
- `cargo run --example example --release` / `cargo run --example readme --release`

Cross-arch (qemu user emulation):

- aarch64: `cargo test --release --features std,derive --test test_correctness` passes. The `@aarch64` snapshot file mismatch is a pre-existing issue on `main` (refresh queued in #41) and is not introduced by this PR — independently reproduced on `git checkout main`.

`cargo tree -p mem_dbg` no longer references hashbrown.

## Relation to #41

Independent of #41 (audit fixes). #41 may merge in either order. After both land, the `@aarch64` snapshot baseline will be in sync with the new aarch64 CI job and the dedup type change will not show up in any snapshot diff (the dedup containers are not rendered).
