### PR TITLE
Implemented traits for Cow using the same implementation rules from Rc and similar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - Added `MemSize`/`MemDbg` implementations for `std::sync::OnceLock`. It uses the same initialized-value accounting as `core::cell::OnceCell`.
 
+- Added `MemSize`/`MemDbg` implementations for `Cow<'_, B>`. Borrowed values follow reference rules, and owned values use `B::Owned` accounting.
+
 
 ## [0.4.1] - 2026-03-25
 

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -13,9 +13,13 @@ use core::{marker::PhantomData, sync::atomic::*};
 use crate::{DbgFlags, FlatType, HashSet, MemDbgImpl, RefDisplay, impl_mem_size::MemSizeHelper};
 
 #[cfg(not(feature = "std"))]
+use alloc::borrow::{Cow, ToOwned};
+#[cfg(not(feature = "std"))]
 use alloc::collections::VecDeque;
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
+#[cfg(feature = "std")]
+use std::borrow::{Cow, ToOwned};
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
 
@@ -264,6 +268,35 @@ impl<T: ?Sized + MemDbgImpl> MemDbgImpl for Box<T> {
         self.as_ref()._mem_dbg_rec_on(
             writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
         )
+    }
+}
+
+// Cow displays borrowed values through the reference implementation and owned
+// values through their owned representation.
+
+impl<B> MemDbgImpl for Cow<'_, B>
+where
+    B: ToOwned + MemDbgImpl + ?Sized,
+    B::Owned: MemDbgImpl,
+{
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        match self {
+            Cow::Borrowed(borrowed) => <&B as MemDbgImpl>::_mem_dbg_rec_on(
+                borrowed, writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            ),
+            Cow::Owned(owned) => <B::Owned as MemDbgImpl>::_mem_dbg_rec_on(
+                owned, writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            ),
+        }
     }
 }
 

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -16,9 +16,13 @@ use core::ops::Deref;
 use crate::{Boolean, False, FlatType, HashMap, MemSize, SizeFlags, True};
 
 #[cfg(not(feature = "std"))]
+use alloc::borrow::{Cow, ToOwned};
+#[cfg(not(feature = "std"))]
 use alloc::collections::VecDeque;
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::borrow::{Cow, ToOwned};
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
 
@@ -248,6 +252,33 @@ impl<T: ?Sized> FlatType for Box<T> {
 impl<T: ?Sized + MemSize> MemSize for Box<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
         core::mem::size_of::<Self>() + <T as MemSize>::mem_size_rec(self.as_ref(), flags, refs)
+    }
+}
+
+// Cow follows borrowed values like references and owned values like their owned
+// representation.
+
+impl<B: ToOwned + ?Sized> FlatType for Cow<'_, B> {
+    type Flat = False;
+}
+
+impl<B> MemSize for Cow<'_, B>
+where
+    B: ToOwned + MemSize + ?Sized,
+    B::Owned: MemSize,
+{
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        core::mem::size_of::<Self>()
+            + match self {
+                Cow::Borrowed(borrowed) => {
+                    <&B as MemSize>::mem_size_rec(borrowed, flags, refs)
+                        - core::mem::size_of::<&B>()
+                }
+                Cow::Owned(owned) => {
+                    <B::Owned as MemSize>::mem_size_rec(owned, flags, refs)
+                        - core::mem::size_of::<B::Owned>()
+                }
+            }
     }
 }
 

--- a/mem_dbg/tests/test_cow.rs
+++ b/mem_dbg/tests/test_cow.rs
@@ -1,0 +1,118 @@
+#![cfg(feature = "std")]
+
+//! Size assertions for `Cow<'_, B>`.
+//!
+//! Borrowed values use reference-following rules, while owned values use the
+//! memory accounting of `B::Owned`.
+
+use mem_dbg::{DbgFlags, MemDbg, MemSize, SizeFlags};
+use std::borrow::Cow;
+
+#[test]
+fn test_cow_borrowed_str_default() {
+    let cow: Cow<'_, str> = Cow::Borrowed("borrowed");
+
+    assert_eq!(
+        cow.mem_size(SizeFlags::default()),
+        core::mem::size_of::<Cow<'_, str>>()
+    );
+}
+
+#[test]
+fn test_cow_borrowed_str_follow_refs() {
+    let value = "borrowed";
+    let cow: Cow<'_, str> = Cow::Borrowed(value);
+
+    assert_eq!(
+        cow.mem_size(SizeFlags::FOLLOW_REFS),
+        core::mem::size_of::<Cow<'_, str>>() + value.len()
+    );
+}
+
+#[test]
+fn test_cow_borrowed_refs_are_deduplicated() {
+    let value = "shared";
+    let pair = (
+        Cow::<'_, str>::Borrowed(value),
+        Cow::<'_, str>::Borrowed(value),
+    );
+
+    assert_eq!(
+        pair.mem_size(SizeFlags::default()),
+        core::mem::size_of::<(Cow<'_, str>, Cow<'_, str>)>()
+    );
+    assert_eq!(
+        pair.mem_size(SizeFlags::FOLLOW_REFS),
+        core::mem::size_of::<(Cow<'_, str>, Cow<'_, str>)>() + value.len()
+    );
+}
+
+#[test]
+fn test_cow_borrowed_slice_follow_refs() {
+    let value = [1_u8, 2, 3, 4];
+    let cow: Cow<'_, [u8]> = Cow::Borrowed(&value);
+
+    assert_eq!(
+        cow.mem_size(SizeFlags::default()),
+        core::mem::size_of::<Cow<'_, [u8]>>()
+    );
+    assert_eq!(
+        cow.mem_size(SizeFlags::FOLLOW_REFS),
+        core::mem::size_of::<Cow<'_, [u8]>>() + value.len() * core::mem::size_of::<u8>()
+    );
+}
+
+#[test]
+fn test_cow_owned_str_size_and_capacity() {
+    let mut value = String::with_capacity(32);
+    value.push_str("owned");
+    let len = value.len();
+    let capacity = value.capacity();
+    let cow: Cow<'_, str> = Cow::Owned(value);
+
+    assert_eq!(
+        cow.mem_size(SizeFlags::default()),
+        core::mem::size_of::<Cow<'_, str>>() + len
+    );
+    assert_eq!(
+        cow.mem_size(SizeFlags::CAPACITY),
+        core::mem::size_of::<Cow<'_, str>>() + capacity
+    );
+}
+
+#[test]
+fn test_cow_owned_slice_size_and_capacity() {
+    let mut value = Vec::with_capacity(8);
+    value.extend_from_slice(&[1_u32, 2, 3]);
+    let len = value.len();
+    let capacity = value.capacity();
+    let cow: Cow<'_, [u32]> = Cow::Owned(value);
+
+    assert_eq!(
+        cow.mem_size(SizeFlags::default()),
+        core::mem::size_of::<Cow<'_, [u32]>>() + len * core::mem::size_of::<u32>()
+    );
+    assert_eq!(
+        cow.mem_size(SizeFlags::CAPACITY),
+        core::mem::size_of::<Cow<'_, [u32]>>() + capacity * core::mem::size_of::<u32>()
+    );
+}
+
+#[test]
+fn test_cow_mem_dbg_borrowed_and_owned() {
+    let borrowed: Cow<'_, str> = Cow::Borrowed("borrowed");
+    let owned: Cow<'_, str> = Cow::Owned(String::from("owned"));
+    let mut output = String::new();
+
+    assert!(
+        borrowed
+            .mem_dbg_depth_on(&mut output, 1, DbgFlags::FOLLOW_REFS)
+            .is_ok()
+    );
+    output.clear();
+    assert!(
+        owned
+            .mem_dbg_depth_on(&mut output, 1, DbgFlags::default())
+            .is_ok()
+    );
+}


### PR DESCRIPTION
As per title, added trait implementations for Cow, following the same approach as per Rc, i.e. the memory allocation always counts.