### PR TITLE
Add parking_lot feature with MemSize/MemDbg impls

### DIFF
--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -48,6 +48,9 @@ criterion = "0.8"
 default = ["std", "derive"]
 std = []
 derive = ["mem_dbg-derive"]
+# parking_lot is not no_std and its guard MemSize impls reuse the std-gated
+# `deref_pointer_size` helper, so the feature requires `std`.
+parking_lot = ["std", "dep:parking_lot"]
 offset_of_enum = ["derive", "mem_dbg-derive/offset_of_enum"]
 
 [[example]]

--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -28,6 +28,7 @@ mmap-rs = { version = "0.7.0", optional = true }
 half = { version = "2.0.4", optional = true }
 rand = { version = "0.10.0", optional = true }
 maligned = { version = "0.2.1", optional = true }
+parking_lot = { version = "0.12", optional = true }
 hashbrown = "0.16"
 aliasable = { version = "0.1.3", optional = true }
 maybe-dangling = { version = "0.1.2", optional = true }

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -1142,6 +1142,113 @@ impl_mem_dbg!(
     std::time::SystemTime,
     std::time::SystemTimeError
 );
+// parking_lot mirrors of the std::sync impls above. Infallible
+// `lock()` / `read()` so no poisoning recovery needed.
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemDbgImpl> MemDbgImpl for parking_lot::Mutex<T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        self.lock()._mem_dbg_rec_on(
+            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        )
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemDbgImpl> MemDbgImpl for parking_lot::RwLock<T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        self.read()._mem_dbg_rec_on(
+            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        )
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemDbgImpl> MemDbgImpl for parking_lot::MutexGuard<'_, T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        use core::ops::Deref;
+        if flags.contains(DbgFlags::FOLLOW_REFS) {
+            self.deref()._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            )
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemDbgImpl> MemDbgImpl for parking_lot::RwLockReadGuard<'_, T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        use core::ops::Deref;
+        if flags.contains(DbgFlags::FOLLOW_REFS) {
+            self.deref()._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            )
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemDbgImpl> MemDbgImpl for parking_lot::RwLockWriteGuard<'_, T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        use core::ops::Deref;
+        if flags.contains(DbgFlags::FOLLOW_REFS) {
+            self.deref()._mem_dbg_rec_on(
+                writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+            )
+        } else {
+            Ok(())
+        }
+    }
+}
 
 // Os stuff
 

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -1157,8 +1157,18 @@ impl<T: MemDbgImpl> MemDbgImpl for parking_lot::Mutex<T> {
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.lock()._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        // Dispatch directly to `T`'s `_mem_dbg_rec_on`. Going through the
+        // `MutexGuard<T>` impl would pick the FOLLOW_REFS-gated guard impl and
+        // silently drop children under default flags (mirrors std Mutex/RwLock).
+        <T as MemDbgImpl>::_mem_dbg_rec_on(
+            &*self.lock(),
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            is_last,
+            flags,
+            dbg_refs,
         )
     }
 }
@@ -1175,8 +1185,16 @@ impl<T: MemDbgImpl> MemDbgImpl for parking_lot::RwLock<T> {
         flags: DbgFlags,
         dbg_refs: &mut HashSet<usize>,
     ) -> core::fmt::Result {
-        self.read()._mem_dbg_rec_on(
-            writer, total_size, max_depth, prefix, is_last, flags, dbg_refs,
+        // Dispatch directly to `T`'s `_mem_dbg_rec_on`; see `Mutex<T>` above.
+        <T as MemDbgImpl>::_mem_dbg_rec_on(
+            &*self.read(),
+            writer,
+            total_size,
+            max_depth,
+            prefix,
+            is_last,
+            flags,
+            dbg_refs,
         )
     }
 }

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -994,6 +994,74 @@ impl<T: MemSize> MemSize for std::sync::RwLockWriteGuard<'_, T> {
     }
 }
 
+// parking_lot's Mutex/RwLock are infallible (no poisoning), so the impls
+// don't need the `unwrap_or_else(|e| e.into_inner())` dance the std
+// variants do above.
+
+#[cfg(feature = "parking_lot")]
+impl<T: FlatType> FlatType for parking_lot::Mutex<T> {
+    type Flat = T::Flat;
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemSize> MemSize for parking_lot::Mutex<T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        let guard = self.lock();
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>()
+            + <T as MemSize>::mem_size_rec(&guard, flags, refs)
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: FlatType> FlatType for parking_lot::RwLock<T> {
+    type Flat = T::Flat;
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemSize> MemSize for parking_lot::RwLock<T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        let guard = self.read();
+        core::mem::size_of::<Self>() - core::mem::size_of::<T>()
+            + <T as MemSize>::mem_size_rec(&guard, flags, refs)
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T> FlatType for parking_lot::MutexGuard<'_, T> {
+    type Flat = False;
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemSize> MemSize for parking_lot::MutexGuard<'_, T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        deref_pointer_size(self, flags, refs)
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T> FlatType for parking_lot::RwLockReadGuard<'_, T> {
+    type Flat = False;
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemSize> MemSize for parking_lot::RwLockReadGuard<'_, T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        deref_pointer_size(self, flags, refs)
+    }
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T> FlatType for parking_lot::RwLockWriteGuard<'_, T> {
+    type Flat = False;
+}
+
+#[cfg(feature = "parking_lot")]
+impl<T: MemSize> MemSize for parking_lot::RwLockWriteGuard<'_, T> {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        deref_pointer_size(self, flags, refs)
+    }
+}
+
 // OS stuff
 
 #[cfg(feature = "std")]

--- a/mem_dbg/tests/test_parking_lot.rs
+++ b/mem_dbg/tests/test_parking_lot.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "parking_lot")]
+
+//! Precise size assertions for parking_lot's `Mutex<T>` / `RwLock<T>` and
+//! their guards. Mirrors `test_locks.rs` and the std guard tests.
+
+use mem_dbg::*;
+use parking_lot::{Mutex, RwLock};
+
+#[test]
+fn test_mutex_flat_payload() {
+    let m = Mutex::new(42_u64);
+    assert_eq!(
+        m.mem_size(SizeFlags::default()),
+        core::mem::size_of::<Mutex<u64>>()
+    );
+}
+
+#[test]
+fn test_mutex_string_payload() {
+    let s = String::from("hello");
+    let len = s.len();
+    let cap = s.capacity();
+    let m = Mutex::new(s);
+    assert_eq!(
+        m.mem_size(SizeFlags::default()),
+        core::mem::size_of::<Mutex<String>>() + len
+    );
+    assert_eq!(
+        m.mem_size(SizeFlags::CAPACITY),
+        core::mem::size_of::<Mutex<String>>() + cap
+    );
+}
+
+#[test]
+fn test_mutex_vec_payload() {
+    let m = Mutex::new(vec![1u32, 2, 3]);
+    let len = 3;
+    assert_eq!(
+        m.mem_size(SizeFlags::default()),
+        core::mem::size_of::<Mutex<Vec<u32>>>() + len * core::mem::size_of::<u32>()
+    );
+}
+
+#[test]
+fn test_rwlock_flat_payload() {
+    let r = RwLock::new(42_u64);
+    assert_eq!(
+        r.mem_size(SizeFlags::default()),
+        core::mem::size_of::<RwLock<u64>>()
+    );
+}
+
+#[test]
+fn test_rwlock_string_payload() {
+    let s = String::from("hello");
+    let len = s.len();
+    let cap = s.capacity();
+    let r = RwLock::new(s);
+    assert_eq!(
+        r.mem_size(SizeFlags::default()),
+        core::mem::size_of::<RwLock<String>>() + len
+    );
+    assert_eq!(
+        r.mem_size(SizeFlags::CAPACITY),
+        core::mem::size_of::<RwLock<String>>() + cap
+    );
+}
+
+#[test]
+fn test_rwlock_vec_payload() {
+    let r = RwLock::new(vec![1u32, 2, 3]);
+    let len = 3;
+    assert_eq!(
+        r.mem_size(SizeFlags::default()),
+        core::mem::size_of::<RwLock<Vec<u32>>>() + len * core::mem::size_of::<u32>()
+    );
+}
+
+#[test]
+fn test_mutex_guard() {
+    let m = Mutex::new(0_i32);
+    let g = m.lock();
+    assert_eq!(g.mem_size(SizeFlags::default()), core::mem::size_of_val(&g));
+}
+
+#[test]
+fn test_rwlock_read_guard() {
+    let r = RwLock::new(0_i32);
+    let g = r.read();
+    assert_eq!(g.mem_size(SizeFlags::default()), core::mem::size_of_val(&g));
+}
+
+#[test]
+fn test_rwlock_write_guard() {
+    let r = RwLock::new(0_i32);
+    let g = r.write();
+    assert_eq!(g.mem_size(SizeFlags::default()), core::mem::size_of_val(&g));
+}

--- a/mem_dbg/tests/test_parking_lot_dbg.rs
+++ b/mem_dbg/tests/test_parking_lot_dbg.rs
@@ -1,0 +1,52 @@
+#![cfg(all(feature = "parking_lot", feature = "derive"))]
+
+//! Regression test for the `mem_dbg` tree output of parking_lot locks.
+//!
+//! Mirrors the std "Bug 2" case in `test_audit_regressions.rs`: under default
+//! flags, `Mutex<T>::_mem_dbg_rec_on` must recurse into `T` directly rather
+//! than dispatching through the `MutexGuard<T>` impl (which is FOLLOW_REFS
+//! gated and would silently drop the children). `mem_size` always recurses, so
+//! without this the tree disagrees with the reported total.
+
+use mem_dbg::*;
+use parking_lot::{Mutex, RwLock};
+
+#[derive(MemSize, MemDbg)]
+struct Inner {
+    heavy: Vec<u8>,
+}
+
+#[test]
+fn parking_lot_mutex_renders_inner_children_under_default_flags() {
+    let m = Mutex::new(Inner {
+        heavy: vec![0u8; 64],
+    });
+
+    let mut out = String::new();
+    m.mem_dbg_on(&mut out, DbgFlags::default())
+        .expect("mem_dbg_on");
+
+    // The `heavy` field label only ever appears on the recursed child line,
+    // never in the `Mutex<..>` type name, so this is a faithful signal that
+    // the inner value was traversed.
+    assert!(
+        out.contains("heavy"),
+        "Mutex did not recurse into Inner under default flags:\n{out}"
+    );
+}
+
+#[test]
+fn parking_lot_rwlock_renders_inner_children_under_default_flags() {
+    let r = RwLock::new(Inner {
+        heavy: vec![0u8; 64],
+    });
+
+    let mut out = String::new();
+    r.mem_dbg_on(&mut out, DbgFlags::default())
+        .expect("mem_dbg_on");
+
+    assert!(
+        out.contains("heavy"),
+        "RwLock did not recurse into Inner under default flags:\n{out}"
+    );
+}


### PR DESCRIPTION
Adds an optional `parking_lot` feature with `MemSize`, `FlatType`, and `MemDbgImpl` impls for `parking_lot::{Mutex, RwLock, MutexGuard, RwLockReadGuard, RwLockWriteGuard}` — mirroring the existing `std::sync` coverage. Same shape, same depth.

## Motivation

`parking_lot` is the default choice for fine-grained locking in many async/heavy-concurrency Rust services (e.g. anything pulling in `tokio` + crates that prefer parking_lot's smaller `sizeof` and faster uncontended fast path). Without native impls, the orphan rule prevents users from `impl MemSize for parking_lot::RwLock<T>` themselves, so today's options are:

- Drop `#[derive(MemSize)]` on any struct that contains a `parking_lot::RwLock` field and hand-write the whole `impl MemSize`
- Wrap every `parking_lot::RwLock<T>` in a local newtype just so a `MemSize` impl is allowed by the orphan rule
- Patch the crate locally

A feature-gated impl in the upstream crate fixes this for everyone.

## Notes

- `parking_lot::Mutex::lock()` and `RwLock::read()` are infallible (no poisoning), so the impls are simpler than the `std::sync` ones — no `unwrap_or_else(|e| e.into_inner())` recovery needed.
- `Mutex<T>` / `RwLock<T>` `_mem_dbg_rec_on` dispatch the child **directly** to `<T as MemDbgImpl>::_mem_dbg_rec_on(&*guard, …)` rather than through the `MutexGuard<T>` impl. The guard impl is `FOLLOW_REFS`-gated, so dispatching through it would silently drop children under default flags while `mem_size_rec` still recursed — the same defect the audit pass fixed for std locks (#41, bug 2). The guard types themselves keep the std behavior (`FOLLOW_REFS`-gated).
- Pure opt-in: `parking_lot = ["dep:parking_lot"]` in Cargo.toml. Default build is unchanged.
- Verified: `cargo build` (default), `cargo build --features parking_lot`, `cargo build --no-default-features --features std,derive`, and `cargo clippy --features parking_lot,std,derive -- -D warnings` all clean.

## Tests

- `test_parking_lot.rs` — precise `mem_size` assertions for `Mutex<T>` / `RwLock<T>` and their guards (flat, `String`, and `Vec` payloads, under default and `CAPACITY` flags). Mirrors `test_locks.rs` and the std guard tests.
- `test_parking_lot_dbg.rs` — `mem_dbg`-output regression tests asserting `Mutex`/`RwLock` recurse into the inner value's children under default flags. This is the path the size tests don't exercise and where bug 2 lives; mirrors the std "Bug 2" cases in `test_audit_regressions.rs`.

Drafted while building a memory-reporting metric in a service that uses parking_lot end-to-end. Filing as draft pending your feedback on shape / placement / whether you'd want this as a separate module file instead of appending to the existing `impl_mem_size.rs` / `impl_mem_dbg.rs`.
