### PR TITLE
fix(tests): align aarch64 GROUP_WIDTH expectation with stdlib hashbrown

### DIFF
--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1070,9 +1070,10 @@ impl MemSize for mmap_rs::MmapMut {
 // If the standard library changes load factor, this code will have to change
 // accordingly.
 
-// Group width for Swiss Tables (hashbrown). This depends on SIMD support:
-// - x86/x86_64 with SSE2: 16 bytes
-// - Other platforms (ARM64 NEON, generic): 8 bytes
+// Group width for Swiss Tables, matching the stdlib's vendored hashbrown.
+// stdlib currently uses SSE2 SIMD on x86/x86_64 (16-byte groups) and the
+// generic (8-byte) implementation everywhere else, including aarch64+NEON
+// — verified by the allocator-vs-formula assertions in test_correctness.rs.
 #[cfg(feature = "std")]
 #[cfg(all(
     any(target_arch = "x86_64", target_arch = "x86"),

--- a/mem_dbg/tests/test_hash_collections.rs
+++ b/mem_dbg/tests/test_hash_collections.rs
@@ -13,16 +13,19 @@
 use mem_dbg::*;
 use std::collections::{HashMap, HashSet};
 
-// Mirror of the constants in impl_mem_size.rs. GROUP_WIDTH is 16 for SSE2/NEON
-// targets and 8 elsewhere.
-#[cfg(any(
-    target_feature = "sse2",
-    all(target_arch = "aarch64", target_feature = "neon"),
+// Mirror of the constants in impl_mem_size.rs, which in turn match what the
+// stdlib's vendored hashbrown actually uses: SSE2 on x86/x86_64 (16-byte
+// groups) and the generic 8-byte path everywhere else (including aarch64+NEON
+// — stdlib does not enable the NEON SIMD probe). Verified end-to-end by
+// test_correctness.rs against the cap allocator.
+#[cfg(all(
+    any(target_arch = "x86_64", target_arch = "x86"),
+    any(target_feature = "sse2", target_env = "msvc"),
 ))]
 const GROUP_WIDTH: usize = 16;
-#[cfg(not(any(
-    target_feature = "sse2",
-    all(target_arch = "aarch64", target_feature = "neon"),
+#[cfg(not(all(
+    any(target_arch = "x86_64", target_arch = "x86"),
+    any(target_feature = "sse2", target_env = "msvc"),
 )))]
 const GROUP_WIDTH: usize = 8;
 


### PR DESCRIPTION
## Summary

- `test_hash_collections` was predicting `GROUP_WIDTH=16` on aarch64+NEON, but the stdlib's vendored hashbrown does not enable the NEON SIMD probe — it uses the generic 8-byte group implementation everywhere except SSE2 x86. The impl in `impl_mem_size.rs` had this right; only the test mirrored the wrong cfg.
- Aligned the test cfg with the impl (`SSE2 + x86` for GW=16, otherwise GW=8) and clarified the explanatory comment in both files with a pointer to `test_correctness.rs` as the allocator-vs-formula ground-truth check.

## Test plan

- [x] `cargo test -p mem_dbg --test test_hash_collections` — all 6 tests pass on aarch64-apple-darwin (previously 4 failed).
- [x] `cargo test -p mem_dbg --test test_correctness` — still passes; the impl's GW choice matches the cap allocator's actual measurements.
- [x] `cargo test -p mem_dbg` — full suite passes on aarch64-apple-darwin.
- [x] Verified on x86_64+SSE2: `test_hash_collections` (6/6), `test_correctness` (1/1), and full `cargo test -p mem_dbg` all pass — no regressions on the GW=16 path.
