### PR TITLE
Add dashmap feature with MemSize/MemDbg impls

### DIFF
--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -48,6 +48,10 @@ criterion = "0.8"
 default = ["std", "derive"]
 std = []
 derive = ["mem_dbg-derive"]
+# DashMap is not no_std and the impls reuse the std-gated Swiss-table
+# machinery (MemSizeHelper2, capacity_to_buckets, GROUP_WIDTH), so the
+# feature requires `std`.
+dashmap = ["std", "dep:dashmap"]
 offset_of_enum = ["derive", "mem_dbg-derive/offset_of_enum"]
 
 [[example]]

--- a/mem_dbg/Cargo.toml
+++ b/mem_dbg/Cargo.toml
@@ -28,6 +28,7 @@ mmap-rs = { version = "0.7.0", optional = true }
 half = { version = "2.0.4", optional = true }
 rand = { version = "0.10.0", optional = true }
 maligned = { version = "0.2.1", optional = true }
+dashmap = { version = "6", optional = true, features = ["raw-api"] }
 hashbrown = "0.16"
 aliasable = { version = "0.1.3", optional = true }
 maybe-dangling = { version = "0.1.2", optional = true }

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -636,6 +636,13 @@ impl<K: FlatType, V: FlatType> MemDbgImpl for std::collections::HashMap<K, V> wh
 {
 }
 
+#[cfg(feature = "dashmap")]
+impl<K: FlatType, V: FlatType, S> MemDbgImpl for dashmap::DashMap<K, V, S> where
+    dashmap::DashMap<K, V, S>:
+        crate::impl_mem_size::MemSizeHelper2<<K as FlatType>::Flat, <V as FlatType>::Flat>
+{
+}
+
 #[cfg(feature = "std")]
 impl<T: FlatType> MemDbgImpl for std::collections::BTreeSet<T> where
     std::collections::BTreeSet<T>: crate::MemSize

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1304,6 +1304,143 @@ fn fix_map_for_capacity<K, V>(
         + if buckets > 0 { GROUP_WIDTH } else { 0 }
 }
 
+// dashmap support. A `DashMap<K, V, S>` is a `Box<[CachePadded<RwLock<HashMap<K,
+// SharedValue<V>, S>>>]>` (hashbrown internally). We acquire a read lock on
+// each shard sequentially (never multiple at once) and reuse the Swiss-Table
+// overhead math above per shard. `SharedValue<V>` is `#[repr(transparent)]` over
+// `V`, so its `size_of` matches `V`.
+
+#[cfg(feature = "dashmap")]
+impl<K, V, S> FlatType for dashmap::DashMap<K, V, S> {
+    type Flat = False;
+}
+
+#[cfg(feature = "dashmap")]
+impl<K: FlatType, V: FlatType, S> MemSize for dashmap::DashMap<K, V, S>
+where
+    dashmap::DashMap<K, V, S>: MemSizeHelper2<<K as FlatType>::Flat, <V as FlatType>::Flat>,
+{
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        <dashmap::DashMap<K, V, S> as MemSizeHelper2<
+            <K as FlatType>::Flat,
+            <V as FlatType>::Flat,
+        >>::mem_size_impl(self, flags, refs)
+    }
+}
+
+#[cfg(feature = "dashmap")]
+fn dashmap_shard_overhead<K, V>(shard_len: usize, shard_cap_for_flag: usize) -> usize {
+    let buckets = capacity_to_buckets(shard_cap_for_flag).unwrap_or(usize::MAX);
+    (buckets - shard_len) * (core::mem::size_of::<K>() + core::mem::size_of::<V>())
+        + buckets * core::mem::size_of::<u8>()
+        + if buckets > 0 { GROUP_WIDTH } else { 0 }
+}
+
+#[cfg(feature = "dashmap")]
+impl<K: FlatType + MemSize + Eq + core::hash::Hash, V: FlatType + MemSize, S: core::hash::BuildHasher + Clone> MemSizeHelper2<True, True>
+    for dashmap::DashMap<K, V, S>
+{
+    fn mem_size_impl(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+        let mut total = core::mem::size_of::<Self>();
+        for shard in self.shards() {
+            total += core::mem::size_of_val(shard);
+            let guard = shard.read();
+            let cap = if flags.contains(SizeFlags::CAPACITY) {
+                guard.capacity()
+            } else {
+                guard.len()
+            };
+            total += (core::mem::size_of::<K>() + core::mem::size_of::<V>()) * guard.len()
+                + dashmap_shard_overhead::<K, V>(guard.len(), cap);
+        }
+        total
+    }
+}
+
+#[cfg(feature = "dashmap")]
+impl<K: FlatType + MemSize + Eq + core::hash::Hash, V: FlatType + MemSize, S: core::hash::BuildHasher + Clone> MemSizeHelper2<True, False>
+    for dashmap::DashMap<K, V, S>
+{
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        let mut total = core::mem::size_of::<Self>();
+        for shard in self.shards() {
+            total += core::mem::size_of_val(shard);
+            let guard = shard.read();
+            let cap = if flags.contains(SizeFlags::CAPACITY) {
+                guard.capacity()
+            } else {
+                guard.len()
+            };
+            // SAFETY: bucket pointers obtained from RawTable::iter() under a
+            // read lock are valid until the lock is released; we deref before
+            // moving on to the next bucket.
+            let entries = core::mem::size_of::<K>() * guard.len()
+                + unsafe { guard.iter() }
+                    .map(|b| {
+                        let (_, v) = unsafe { b.as_ref() };
+                        <V as MemSize>::mem_size_rec(v.get(), flags, refs)
+                    })
+                    .sum::<usize>();
+            total += entries + dashmap_shard_overhead::<K, V>(guard.len(), cap);
+        }
+        total
+    }
+}
+
+#[cfg(feature = "dashmap")]
+impl<K: FlatType + MemSize + Eq + core::hash::Hash, V: FlatType + MemSize, S: core::hash::BuildHasher + Clone> MemSizeHelper2<False, True>
+    for dashmap::DashMap<K, V, S>
+{
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        let mut total = core::mem::size_of::<Self>();
+        for shard in self.shards() {
+            total += core::mem::size_of_val(shard);
+            let guard = shard.read();
+            let cap = if flags.contains(SizeFlags::CAPACITY) {
+                guard.capacity()
+            } else {
+                guard.len()
+            };
+            let entries = unsafe { guard.iter() }
+                .map(|b| {
+                    let (k, _) = unsafe { b.as_ref() };
+                    <K as MemSize>::mem_size_rec(k, flags, refs)
+                })
+                .sum::<usize>()
+                + core::mem::size_of::<V>() * guard.len();
+            total += entries + dashmap_shard_overhead::<K, V>(guard.len(), cap);
+        }
+        total
+    }
+}
+
+#[cfg(feature = "dashmap")]
+impl<K: FlatType + MemSize + Eq + core::hash::Hash, V: FlatType + MemSize, S: core::hash::BuildHasher + Clone> MemSizeHelper2<False, False>
+    for dashmap::DashMap<K, V, S>
+{
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        let mut total = core::mem::size_of::<Self>();
+        for shard in self.shards() {
+            total += core::mem::size_of_val(shard);
+            let guard = shard.read();
+            let cap = if flags.contains(SizeFlags::CAPACITY) {
+                guard.capacity()
+            } else {
+                guard.len()
+            };
+            let entries = unsafe { guard.iter() }
+                .map(|b| {
+                    let (k, v) = unsafe { b.as_ref() };
+                    <K as MemSize>::mem_size_rec(k, flags, refs)
+                        + <V as MemSize>::mem_size_rec(v.get(), flags, refs)
+                })
+                .sum::<usize>();
+            total += entries + dashmap_shard_overhead::<K, V>(guard.len(), cap);
+        }
+        total
+    }
+}
+
 /// Estimates the heap-allocated memory of a BTree-based container.
 ///
 /// The standard library's `BTreeMap` and `BTreeSet` use a B-Tree with a

--- a/mem_dbg/tests/test_dashmap.rs
+++ b/mem_dbg/tests/test_dashmap.rs
@@ -1,0 +1,177 @@
+#![cfg(feature = "dashmap")]
+
+//! Size assertions for `dashmap::DashMap<K, V, S>`. DashMap is internally
+//! `Box<[CachePadded<RwLock<RawTable<(K, SharedValue<V>)>>>]>` with `SharedValue<V>`
+//! being `#[repr(transparent)]` over `V`. The impl walks each shard under a read
+//! lock and applies the same Swiss-Table overhead formula used for std maps;
+//! this test replicates that formula and checks exact agreement.
+
+use dashmap::DashMap;
+use mem_dbg::*;
+
+// Mirror of constants in impl_mem_size.rs: SSE2 on x86/x86_64 only, generic
+// 8-byte path everywhere else (including aarch64+NEON).
+#[cfg(all(
+    any(target_arch = "x86_64", target_arch = "x86"),
+    any(target_feature = "sse2", target_env = "msvc"),
+))]
+const GROUP_WIDTH: usize = 16;
+#[cfg(not(all(
+    any(target_arch = "x86_64", target_arch = "x86"),
+    any(target_feature = "sse2", target_env = "msvc"),
+)))]
+const GROUP_WIDTH: usize = 8;
+
+fn capacity_to_buckets(cap: usize) -> Option<usize> {
+    if cap == 0 {
+        return Some(0);
+    }
+    if cap < 8 {
+        return Some(if cap < 4 { 4 } else { 8 });
+    }
+    let adjusted_cap = cap.checked_mul(8)? / 7;
+    Some(adjusted_cap.next_power_of_two())
+}
+
+fn predicted_dashmap_size<K, V, S, FK, FV>(
+    map: &DashMap<K, V, S>,
+    flags: SizeFlags,
+    mut key_bytes: FK,
+    mut val_bytes: FV,
+) -> usize
+where
+    K: Eq + core::hash::Hash,
+    S: core::hash::BuildHasher + Clone,
+    FK: FnMut(&K) -> usize,
+    FV: FnMut(&V) -> usize,
+{
+    let mut total = core::mem::size_of::<DashMap<K, V, S>>();
+    for shard in map.shards() {
+        total += core::mem::size_of_val(shard);
+        let guard = shard.read();
+        let cap = if flags.contains(SizeFlags::CAPACITY) {
+            guard.capacity()
+        } else {
+            guard.len()
+        };
+        let buckets = capacity_to_buckets(cap).unwrap_or(usize::MAX);
+        let mut entries = 0;
+        for bucket in unsafe { guard.iter() } {
+            let (k, v) = unsafe { bucket.as_ref() };
+            entries += key_bytes(k) + val_bytes(v.get());
+        }
+        total += entries
+            + (buckets - guard.len()) * (core::mem::size_of::<K>() + core::mem::size_of::<V>())
+            + buckets * core::mem::size_of::<u8>()
+            + if buckets > 0 { GROUP_WIDTH } else { 0 };
+    }
+    total
+}
+
+#[test]
+fn flat_flat_empty() {
+    let m: DashMap<u64, u64> = DashMap::new();
+    let pred = predicted_dashmap_size(
+        &m,
+        SizeFlags::default(),
+        |_| core::mem::size_of::<u64>(),
+        |_| core::mem::size_of::<u64>(),
+    );
+    assert_eq!(m.mem_size(SizeFlags::default()), pred);
+}
+
+#[test]
+fn flat_flat_populated() {
+    let m: DashMap<u64, u64> = DashMap::new();
+    for i in 0..100 {
+        m.insert(i, i * 2);
+    }
+    for flags in [SizeFlags::default(), SizeFlags::CAPACITY] {
+        let pred = predicted_dashmap_size(
+            &m,
+            flags,
+            |_| core::mem::size_of::<u64>(),
+            |_| core::mem::size_of::<u64>(),
+        );
+        assert_eq!(m.mem_size(flags), pred, "flags={:?}", flags);
+    }
+}
+
+#[test]
+fn flat_nonflat_values() {
+    let m: DashMap<u64, String> = DashMap::new();
+    for i in 0..32 {
+        m.insert(i, format!("value-{i}-with-some-content"));
+    }
+    for flags in [SizeFlags::default(), SizeFlags::CAPACITY] {
+        let pred = predicted_dashmap_size(
+            &m,
+            flags,
+            |_| core::mem::size_of::<u64>(),
+            |s: &String| {
+                core::mem::size_of::<String>()
+                    + if flags.contains(SizeFlags::CAPACITY) {
+                        s.capacity()
+                    } else {
+                        s.len()
+                    }
+            },
+        );
+        assert_eq!(m.mem_size(flags), pred, "flags={:?}", flags);
+    }
+}
+
+#[test]
+fn nonflat_flat_keys() {
+    let m: DashMap<String, u32> = DashMap::new();
+    for i in 0..32 {
+        m.insert(format!("key-{i}-padding"), i);
+    }
+    for flags in [SizeFlags::default(), SizeFlags::CAPACITY] {
+        let pred = predicted_dashmap_size(
+            &m,
+            flags,
+            |s: &String| {
+                core::mem::size_of::<String>()
+                    + if flags.contains(SizeFlags::CAPACITY) {
+                        s.capacity()
+                    } else {
+                        s.len()
+                    }
+            },
+            |_| core::mem::size_of::<u32>(),
+        );
+        assert_eq!(m.mem_size(flags), pred, "flags={:?}", flags);
+    }
+}
+
+#[test]
+fn nonflat_nonflat() {
+    let m: DashMap<String, Vec<u32>> = DashMap::new();
+    for i in 0..16 {
+        m.insert(format!("k-{i}"), (0..i).collect());
+    }
+    for flags in [SizeFlags::default(), SizeFlags::CAPACITY] {
+        let pred = predicted_dashmap_size(
+            &m,
+            flags,
+            |s: &String| {
+                core::mem::size_of::<String>()
+                    + if flags.contains(SizeFlags::CAPACITY) {
+                        s.capacity()
+                    } else {
+                        s.len()
+                    }
+            },
+            |v: &Vec<u32>| {
+                core::mem::size_of::<Vec<u32>>()
+                    + if flags.contains(SizeFlags::CAPACITY) {
+                        v.capacity()
+                    } else {
+                        v.len()
+                    } * core::mem::size_of::<u32>()
+            },
+        );
+        assert_eq!(m.mem_size(flags), pred, "flags={:?}", flags);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an optional `dashmap` feature with `MemSize`, `MemDbgImpl`, and `FlatType` impls for `dashmap::DashMap<K, V, S>`.
- DashMap is internally `Box<[CachePadded<RwLock<RawTable<(K, SharedValue<V>)>>>]>`. The impls iterate shards under a sequential read lock (never multiple simultaneously) and reuse the same Swiss-Table overhead formula as the std `HashMap`, applied per shard. `SharedValue<V>` is `#[repr(transparent)]` over `V`, so `size_of` matches.
- Provides all four `MemSizeHelper2<KFlat, VFlat>` specializations:
  - `(True, True)` — pure arithmetic, O(num_shards); the headline O(1) case for flat K/V.
  - `(True, False)`, `(False, True)`, `(False, False)` — iterate entries via the `RawTable` raw iterator under the shard read guard to recurse into non-flat sides.
- Enables `dashmap/raw-api` to access `shards()`. The feature is additive and pulls no extra deps.

## Test plan

- [x] `cargo test -p mem_dbg --features dashmap --test test_dashmap` — 5/5 pass (empty, flat-flat populated, flat-nonflat, nonflat-flat, nonflat-nonflat) with both default and CAPACITY flags. The test mirrors the impl's per-shard formula and asserts exact agreement.
- [x] Builds cleanly: `cargo build -p mem_dbg --features dashmap`.
- [x] Verified on x86_64 (impl/test both use SSE2 `GROUP_WIDTH=16` cfg; matches existing `impl_mem_size.rs` constants).
- [ ] CI matrix coverage for `--features dashmap` (no separate CI job added in this PR).

## Notes

- Targets `dashmap = "6"` (matching the repo's convention of single-major pinning, e.g. `parking_lot = "0.12"`).
- Bound on the four helper impls: `K: FlatType + MemSize + Eq + Hash, V: FlatType + MemSize, S: BuildHasher + Clone` — minimum needed to call `shards()` and `RawTable::iter()`.
- `RawTable::iter()` is unsafe; bucket pointer deref is done inside the same read-guard scope so pointers remain valid.
