### PR TITLE
Add MemSize/MemDbg implementations for LinkedList<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Added `MemSize`/`MemDbg` implementations, behind the `maybe_dangling`
   feature, for `maybe_dangling::MaybeDangling<T>`.
 
+- Added `MemSize`/`MemDbg` implementations for `LinkedList<T>`, available under both `no_std + alloc` and `std`. Per-node accounting mirrors the standard library's internal `Node<T>` layout (two pointers plus the element), so the reported size is exact for flat element types and correctly recurses for non-flat ones. `LinkedList` has no reserved spare capacity, so `SizeFlags::CAPACITY` returns the same value as the default.
+
 - Added handle-only `MemSize`/`MemDbg` implementations for `*const T`,
   `*mut T`, `std::rc::Weak<T>`, and `std::sync::Weak<T>`. None of these are
   followed: their referents are neither dereferenced nor counted, and the

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -15,13 +15,13 @@ use crate::{DbgFlags, FlatType, HashSet, MemDbgImpl, RefDisplay, impl_mem_size::
 #[cfg(not(feature = "std"))]
 use alloc::borrow::{Cow, ToOwned};
 #[cfg(not(feature = "std"))]
-use alloc::collections::{BinaryHeap, VecDeque};
+use alloc::collections::{BinaryHeap, LinkedList, VecDeque};
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String, vec::Vec};
 #[cfg(feature = "std")]
 use std::borrow::{Cow, ToOwned};
 #[cfg(feature = "std")]
-use std::collections::{BinaryHeap, VecDeque};
+use std::collections::{BinaryHeap, LinkedList, VecDeque};
 
 /// Implements [`MemDbg`](crate::MemDbg) using the default implementation of
 /// [`MemDbgImpl`].
@@ -466,6 +466,13 @@ impl<T: FlatType + MemDbgImpl> MemDbgImpl for BinaryHeap<T> where
 
 impl<T: FlatType + MemDbgImpl> MemDbgImpl for VecDeque<T> where
     VecDeque<T>: MemSizeHelper<<T as FlatType>::Flat>
+{
+}
+
+// LinkedList
+
+impl<T: FlatType + MemDbgImpl> MemDbgImpl for LinkedList<T> where
+    LinkedList<T>: MemSizeHelper<<T as FlatType>::Flat>
 {
 }
 

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -658,10 +658,12 @@ impl<T: FlatType + MemSize> MemSizeHelper<False> for VecDeque<T> {
 /// the formula reports 48 bytes against an actual 64.
 ///
 /// A mirror struct with the same field types and order sidesteps this. The
-/// compiler applies its default-`repr` layout rules identically to both, so
+/// default Rust representation is not formally specified across distinct
+/// type definitions, but rustc's current layout algorithm is deterministic
+/// for two structs with identical field types in identical order, so
 /// `size_of::<LinkedListNode<T>>()` matches `size_of::<Node<T>>()` for any
-/// `T`. The same pattern is used for `Rc<T>` and `Arc<T>` (see `RcInner`
-/// and `ArcInner`).
+/// `T`. We accept this implementation detail, same as the `RcInner` and
+/// `ArcInner` mirrors used for `Rc<T>` and `Arc<T>`.
 ///
 /// # Stability
 ///

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -18,13 +18,13 @@ use crate::{Boolean, False, FlatType, HashMap, MemSize, SizeFlags, True};
 #[cfg(not(feature = "std"))]
 use alloc::borrow::{Cow, ToOwned};
 #[cfg(not(feature = "std"))]
-use alloc::collections::{BinaryHeap, VecDeque};
+use alloc::collections::{BinaryHeap, LinkedList, VecDeque};
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String, vec::Vec};
 #[cfg(feature = "std")]
 use std::borrow::{Cow, ToOwned};
 #[cfg(feature = "std")]
-use std::collections::{BinaryHeap, VecDeque};
+use std::collections::{BinaryHeap, LinkedList, VecDeque};
 
 /// A basic implementation using [`core::mem::size_of`], setting
 /// [`FlatType::Flat`] to the specified type ([`True`] or [`False`]).
@@ -626,6 +626,86 @@ impl<T: FlatType + MemSize> MemSizeHelper<False> for VecDeque<T> {
             } else {
                 0
             }
+    }
+}
+
+// LinkedList allocates one node per element, with no reserved spare capacity,
+// so `SizeFlags::CAPACITY` is equivalent to the default for this container.
+
+/// Layout-equivalent mirror of the private `Node<T>` struct that
+/// [`LinkedList<T>`](alloc::collections::LinkedList) heap-allocates for each
+/// element. Field types, field order, and `repr` match the standard-library
+/// definition:
+///
+/// ```ignore
+/// struct Node<T> {
+///     next: Option<NonNull<Node<T>>>,
+///     prev: Option<NonNull<Node<T>>>,
+///     element: T,
+/// }
+/// ```
+///
+/// # Why this type exists
+///
+/// The [`MemSize`] impl for `LinkedList<T>` needs the per-node heap size,
+/// which is `size_of::<Node<T>>()`. `Node<T>` is `pub(crate)` in `std`, so
+/// we cannot name it.
+///
+/// A hand-rolled formula like `2 * size_of::<usize>() + size_of::<T>()` is
+/// wrong whenever `align_of::<T>() > align_of::<usize>()`: the compiler
+/// inserts padding before `T` and rounds the total size up to a multiple of
+/// `align_of::<T>()`. For `T` with `align(32)` and `size_of::<T>() == 32`
+/// the formula reports 48 bytes against an actual 64.
+///
+/// A mirror struct with the same field types and order sidesteps this. The
+/// compiler applies its default-`repr` layout rules identically to both, so
+/// `size_of::<LinkedListNode<T>>()` matches `size_of::<Node<T>>()` for any
+/// `T`. The same pattern is used for `Rc<T>` and `Arc<T>` (see `RcInner`
+/// and `ArcInner`).
+///
+/// # Stability
+///
+/// Re-exported through [`crate::LinkedListNode`] only so integration tests
+/// can compute expected sizes against the same definition. Not part of the
+/// stable public API. If a future standard-library release changes the
+/// `LinkedList` node layout, this type must be updated to match.
+#[doc(hidden)]
+pub struct LinkedListNode<T> {
+    _next: Option<core::ptr::NonNull<LinkedListNode<T>>>,
+    _prev: Option<core::ptr::NonNull<LinkedListNode<T>>>,
+    _element: T,
+}
+
+impl<T> FlatType for LinkedList<T> {
+    type Flat = False;
+}
+
+impl<T: FlatType> MemSize for LinkedList<T>
+where
+    LinkedList<T>: MemSizeHelper<<T as FlatType>::Flat>,
+{
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        <LinkedList<T> as MemSizeHelper<<T as FlatType>::Flat>>::mem_size_impl(self, flags, refs)
+    }
+}
+
+impl<T: FlatType + MemSize> MemSizeHelper<True> for LinkedList<T> {
+    #[inline(always)]
+    fn mem_size_impl(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+        core::mem::size_of::<Self>() + self.len() * core::mem::size_of::<LinkedListNode<T>>()
+    }
+}
+
+impl<T: FlatType + MemSize> MemSizeHelper<False> for LinkedList<T> {
+    #[inline(always)]
+    fn mem_size_impl(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        let per_node_overhead =
+            core::mem::size_of::<LinkedListNode<T>>() - core::mem::size_of::<T>();
+        core::mem::size_of::<Self>()
+            + self
+                .iter()
+                .map(|x| <T as MemSize>::mem_size_rec(x, flags, refs) + per_node_overhead)
+                .sum::<usize>()
     }
 }
 

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -27,6 +27,13 @@ pub use mem_dbg_derive::{MemDbg, MemSize};
 mod impl_mem_dbg;
 mod impl_mem_size;
 
+/// Layout-equivalent mirror of the private internal node `LinkedList<T>`
+/// heap-allocates per element. Re-exposed so integration tests can compute
+/// expected sizes against the same definition. Not part of the stable
+/// public API. See the type's documentation for details.
+#[doc(hidden)]
+pub use impl_mem_size::LinkedListNode;
+
 mod utils;
 pub use utils::*;
 

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -27,8 +27,8 @@ pub use mem_dbg_derive::{MemDbg, MemSize};
 mod impl_mem_dbg;
 mod impl_mem_size;
 
-/// Layout-equivalent mirror of the private internal node `LinkedList<T>`
-/// heap-allocates per element. Re-exposed so integration tests can compute
+/// Layout-equivalent mirror of the private internal node that `LinkedList<T>`
+/// heap-allocates per element. Re-exported so integration tests can compute
 /// expected sizes against the same definition. Not part of the stable
 /// public API. See the type's documentation for details.
 #[doc(hidden)]

--- a/mem_dbg/tests/all_types_helper.rs
+++ b/mem_dbg/tests/all_types_helper.rs
@@ -10,7 +10,7 @@ use core::ptr::NonNull;
 use core::sync::atomic::*;
 use mem_dbg::*;
 use std::collections::hash_map::{DefaultHasher, RandomState};
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::ffi::{OsStr, OsString};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -138,6 +138,7 @@ pub struct AllTypesStruct<'a> {
     btree_map_copy: BTreeMap<i32, i32>,
     vec_deque: VecDeque<u32>,
     binary_heap: BinaryHeap<u32>,
+    linked_list: LinkedList<u32>,
 
     // Hash builders
     build_hasher: BuildHasherDefault<DefaultHasher>,
@@ -171,9 +172,10 @@ pub struct AllTypesStruct<'a> {
     arc: Arc<i32>,
     rc: Rc<i32>,
 
-    // Nested VecDeque
+    // Nested collections
     vec_deque_nested: VecDeque<Vec<i32>>,
     binary_heap_nested: BinaryHeap<Vec<i32>>,
+    linked_list_nested: LinkedList<Vec<i32>>,
 
     // Guards
     mutex_guard: MutexGuard<'a, i32>,
@@ -241,6 +243,10 @@ where
     let mut binary_heap: BinaryHeap<u32> = BinaryHeap::new();
     binary_heap.push(10);
     binary_heap.push(20);
+
+    let mut linked_list: LinkedList<u32> = LinkedList::new();
+    linked_list.push_back(10);
+    linked_list.push_back(20);
 
     let once_cell = OnceCell::new();
     once_cell.set("initialized".to_string()).unwrap();
@@ -357,6 +363,7 @@ where
         btree_map_copy,
         vec_deque,
         binary_heap,
+        linked_list,
 
         build_hasher: BuildHasherDefault::<DefaultHasher>::default(),
         random_state: RandomState::new(),
@@ -384,9 +391,10 @@ where
         arc: Arc::new(10),
         rc: Rc::new(20),
 
-        // Nested VecDeque
+        // Nested collections
         vec_deque_nested: VecDeque::from(vec![vec![1, 2], vec![3]]),
         binary_heap_nested: BinaryHeap::from(vec![vec![1, 2], vec![3]]),
+        linked_list_nested: LinkedList::from_iter(vec![vec![1, 2], vec![3]]),
 
         // Guards
         mutex_guard: mutex_source.lock().unwrap(),

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.02% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+69_603 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,15 +49,15 @@ expression: output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.01% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -80,7 +80,7 @@ expression: output
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
      8 B   0.01% │ ╰╴start: usize
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% │ ├╴start: usize
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
@@ -95,15 +95,15 @@ expression: output
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.45% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.52% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+    72 B   0.10% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -117,29 +117,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.15% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.14% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.87% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.86% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.02% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.78% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_568 B   6.72% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_568 B   6.72% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 7_928 B  11.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.06% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.21% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_016 B  10.32% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_956 B  10.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-11_704 B  17.21% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_768 B   6.85% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_768 B   6.85% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_328 B  11.97% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.37% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.28% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.39% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,15 +49,15 @@ expression: output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.01% ├╴array: [u8; 10]
-    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -80,7 +80,7 @@ expression: output
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
      8 B   0.01% │ ╰╴start: usize
-    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% │ ├╴start: usize
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
@@ -91,19 +91,20 @@ expression: output
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   176 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   305 B   0.45% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.52% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.02% ├╴path: &std::path::Path
@@ -116,28 +117,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  11.91% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  11.89% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  12.15% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  12.14% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.02% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_768 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_768 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_328 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.15% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_216 B  10.40% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 7_156 B  10.31% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-12_104 B  17.44% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.78% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_568 B   6.72% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_568 B   6.72% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 7_928 B  11.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.06% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.21% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_016 B  10.32% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_956 B  10.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+11_704 B  17.21% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -54,7 +54,7 @@ expression: output
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -93,16 +93,17 @@ expression: output
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
    120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.40% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.07% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     21 B   0.04% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.62% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.62% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    64 B   0.13% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.39% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_224 B   6.32% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_224 B   6.32% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 5_248 B  10.28% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.42% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_024 B   6.11% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_024 B   6.11% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 4_848 B   9.79% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.21% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_468 B   8.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_468 B   8.76% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 7_052 B  13.82% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.80% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_268 B   8.62% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_268 B   8.62% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 6_652 B  13.43% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+51_119 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -54,7 +54,7 @@ expression: output
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -90,19 +90,19 @@ expression: output
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
-    23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
+    23 B   0.04% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   120 B   0.23% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.40% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     36 B   0.07% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
@@ -117,29 +117,29 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.62% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.62% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.13% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.39% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.42% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_024 B   6.11% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_024 B   6.11% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 4_848 B   9.79% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_224 B   6.31% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_224 B   6.31% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 5_248 B  10.27% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.21% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   3.80% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_268 B   8.62% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_268 B   8.62% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 6_652 B  13.43% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_468 B   8.74% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_468 B   8.74% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 7_052 B  13.80% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -103,6 +103,7 @@ expression: output
    128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.10% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,13 +117,14 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  11.89% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  11.88% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.86% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.85% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
@@ -130,14 +132,14 @@ expression: output
    704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.75% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_776 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_776 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_336 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 4_776 B   6.85% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_776 B   6.85% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_336 B  11.96% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_216 B  10.38% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 7_156 B  10.30% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-12_104 B  17.42% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.13% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.36% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.27% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.37% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -125,9 +125,9 @@ expression: output
     92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63175 B ⏺
+68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+69_603 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@aarch64.snap
@@ -1,5 +1,0 @@
----
-source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: depth_output
----
-69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+51_119 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.02% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+69_603 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,21 +49,21 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.01% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
     43 B   0.06% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     43 B   0.06% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
@@ -74,15 +74,15 @@ expression: depth_output
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.45% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.52% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+    72 B   0.10% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -96,29 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.15% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.14% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.87% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.86% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.02% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.78% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_568 B   6.72% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_568 B   6.72% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 7_928 B  11.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.06% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.21% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_016 B  10.32% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_956 B  10.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-11_704 B  17.21% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_768 B   6.85% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_768 B   6.85% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_328 B  11.97% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.37% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.28% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.39% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,40 +49,41 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.01% ├╴array: [u8; 10]
-    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
     43 B   0.06% ├╴tuple4: (i32, alloc::string::String, f64, bool)
     43 B   0.06% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
     16 B   0.02% ├╴range: core::ops::range::Range<usize>
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   176 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   305 B   0.45% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.52% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.02% ├╴path: &std::path::Path
@@ -95,28 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  11.91% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  11.89% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  12.15% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  12.14% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.02% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_768 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_768 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_328 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.15% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_216 B  10.40% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 7_156 B  10.31% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-12_104 B  17.44% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.78% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_568 B   6.72% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_568 B   6.72% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 7_928 B  11.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.06% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.21% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_016 B  10.32% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_956 B  10.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+11_704 B  17.21% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -54,7 +54,7 @@ expression: depth_output
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -72,16 +72,17 @@ expression: depth_output
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
    120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.40% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.07% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     21 B   0.04% ├╴path_buf: std::path::PathBuf
@@ -95,28 +96,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.62% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.62% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    64 B   0.13% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.39% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_224 B   6.32% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_224 B   6.32% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 5_248 B  10.28% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.42% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_024 B   6.11% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_024 B   6.11% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 4_848 B   9.79% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.21% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_468 B   8.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_468 B   8.76% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 7_052 B  13.82% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.80% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_268 B   8.62% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_268 B   8.62% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 6_652 B  13.43% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+51_119 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -54,7 +54,7 @@ expression: depth_output
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -69,19 +69,19 @@ expression: depth_output
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
-    23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
+    23 B   0.04% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   120 B   0.23% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.40% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     36 B   0.07% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
@@ -96,29 +96,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.62% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.62% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.13% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.39% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.42% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_024 B   6.11% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_024 B   6.11% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 4_848 B   9.79% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_224 B   6.31% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_224 B   6.31% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 5_248 B  10.27% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.21% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   3.80% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_268 B   8.62% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_268 B   8.62% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 6_652 B  13.43% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_468 B   8.74% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_468 B   8.74% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 7_052 B  13.80% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -104,9 +104,9 @@ expression: depth_output
     92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -82,6 +82,7 @@ expression: depth_output
    128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.10% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,13 +96,14 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  11.89% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  11.88% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.86% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.85% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
@@ -109,14 +111,14 @@ expression: depth_output
    704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.75% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_776 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_776 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_336 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 4_776 B   6.85% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_776 B   6.85% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_336 B  11.96% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_216 B  10.38% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 7_156 B  10.30% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-12_104 B  17.42% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.13% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.36% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.27% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.37% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+69_603 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,15 +49,15 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.01% ├╴array: [u8; 10]
-    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
+    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -80,7 +80,7 @@ expression: depth_output
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
      8 B   0.01% │ ╰╴start: usize
-    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% │ ├╴start: usize
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
@@ -95,15 +95,15 @@ expression: depth_output
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.45% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.52% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+    72 B   0.10% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -117,29 +117,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  12.15% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  12.14% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.87% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.86% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.02% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.78% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_568 B   6.72% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_568 B   6.72% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 7_928 B  11.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.06% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.21% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_016 B  10.32% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_956 B  10.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-11_704 B  17.21% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_768 B   6.85% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_768 B   6.85% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_328 B  11.97% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.37% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.28% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.39% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.02% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_415 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+68_003 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -49,15 +49,15 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
-    24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
+    24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     76 B   0.11% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.01% ├╴array: [u8; 10]
-    52 B   0.07% ├╴array_str: [alloc::string::String; 2]
+    52 B   0.08% ├╴array_str: [alloc::string::String; 2]
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.06% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
-    38 B   0.05% ├╴tuple2: (i32, alloc::string::String)
+    38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
      4 B   0.01% │ ├╴0: i32 [4B]
     30 B   0.04% │ ╰╴1: alloc::string::String
     43 B   0.06% ├╴tuple3: (i32, alloc::string::String, f64)
@@ -80,7 +80,7 @@ expression: depth_output
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
      8 B   0.01% │ ╰╴start: usize
-    24 B   0.03% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
      8 B   0.01% │ ├╴start: usize
      8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
@@ -91,19 +91,20 @@ expression: depth_output
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   176 B   0.25% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    92 B   0.13% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   176 B   0.26% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    92 B   0.14% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     84 B   0.12% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   305 B   0.44% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   352 B   0.51% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   305 B   0.45% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   352 B   0.52% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   128 B   0.19% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.02% ├╴path: &std::path::Path
@@ -116,28 +117,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  11.91% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  11.89% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  12.15% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  12.14% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    92 B   0.14% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.00% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.02% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.74% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_768 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_768 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_328 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
-    24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
-    24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.15% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_216 B  10.40% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 7_156 B  10.31% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-12_104 B  17.44% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-    72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher
+ 1_208 B   1.78% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 4_568 B   6.72% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_568 B   6.72% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 7_928 B  11.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+    24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.06% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+    24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 2_184 B   3.21% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_016 B  10.32% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_956 B  10.23% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+11_704 B  17.21% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+    72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-51_027 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -54,7 +54,7 @@ expression: depth_output
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -93,16 +93,17 @@ expression: depth_output
     23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
    120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.40% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.07% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     21 B   0.04% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.62% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.62% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    64 B   0.13% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.39% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_224 B   6.32% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_224 B   6.32% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 5_248 B  10.28% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.42% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_024 B   6.11% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_024 B   6.11% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 4_848 B   9.79% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.21% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_468 B   8.76% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_468 B   8.76% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 7_052 B  13.82% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.80% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_268 B   8.62% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_268 B   8.62% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 6_652 B  13.43% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-49_519 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+51_119 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -54,7 +54,7 @@ expression: depth_output
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>
     40 B   0.08% ├╴vec_str: alloc::vec::Vec<alloc::string::String>
     10 B   0.02% ├╴array: [u8; 10]
-    28 B   0.06% ├╴array_str: [alloc::string::String; 2]
+    28 B   0.05% ├╴array_str: [alloc::string::String; 2]
     20 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     22 B   0.04% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     22 B   0.04% ├╴tuple2: (i32, alloc::string::String)
@@ -90,19 +90,19 @@ expression: depth_output
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
      8 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
-    23 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
+    23 B   0.04% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
     12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     30 B   0.06% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
-    68 B   0.14% ├╴hash_set: std::collections::hash::set::HashSet<i32>
+    68 B   0.13% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    101 B   0.20% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
-   120 B   0.24% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
-    84 B   0.17% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
+   120 B   0.23% ├╴hash_map: std::collections::hash::map::HashMap<alloc::string::String, i32>
+    84 B   0.16% ├╴hash_map_copy: std::collections::hash::map::HashMap<i32, i32>
     64 B   0.13% ├╴btree_set: alloc::collections::btree::set::BTreeSet<i32>
-   153 B   0.31% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
-   200 B   0.40% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-   108 B   0.22% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
+   153 B   0.30% ├╴btree_set_str: alloc::collections::btree::set::BTreeSet<alloc::string::String>
+   200 B   0.39% ├╴btree_map: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+   108 B   0.21% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     32 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
-    28 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    28 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
     36 B   0.07% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
@@ -117,29 +117,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  16.62% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  16.62% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  16.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  16.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
-    52 B   0.11% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
-    48 B   0.10% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+    52 B   0.10% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
+    48 B   0.09% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.13% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
      8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
      8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
      8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.06% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.39% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.35% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.06% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.42% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_024 B   6.11% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_024 B   6.11% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 4_848 B   9.79% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_200 B   2.35% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_224 B   6.31% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_224 B   6.31% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 5_248 B  10.27% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.02% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.21% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.14% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.02% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   3.80% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 4_268 B   8.62% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 4_268 B   8.62% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 6_652 B  13.43% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   3.69% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 4_468 B   8.74% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 4_468 B   8.74% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 7_052 B  13.80% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.13% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -125,9 +125,9 @@ expression: depth_output
     92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-69_487 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+69_675 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -103,6 +103,7 @@ expression: depth_output
    128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.10% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,13 +117,14 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.02% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  11.89% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  11.88% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  11.86% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  11.85% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.13% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.12% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.17% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
@@ -130,14 +132,14 @@ expression: depth_output
    704 B   1.01% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.75% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 4_776 B   6.87% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 4_776 B   6.87% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 8_336 B  12.00% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 4_776 B   6.85% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 4_776 B   6.85% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 8_336 B  11.96% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.02% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.14% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 7_216 B  10.38% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 7_156 B  10.30% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-12_104 B  17.42% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.13% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 7_216 B  10.36% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 7_156 B  10.27% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+12_104 B  17.37% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.10% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: depth_output
+expression: output
 ---
-62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_103 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -58,19 +58,40 @@ expression: depth_output
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
+     4 B   0.01% │ ├╴0: i32 [4B]
+    30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
+     4 B   0.01% │ ├╴0: i32 [4B]
+    27 B   0.04% │ ├╴1: alloc::string::String
+     8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
+     4 B   0.01% │ ├╴0: i32
+    27 B   0.04% │ ├╴1: alloc::string::String
+     8 B   0.01% │ ├╴2: f64
+     1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
+     4 B   0.01% │ ├╴0: i32
+    27 B   0.04% │ ├╴1: alloc::string::String
+     8 B   0.01% │ ├╴2: f64
+     1 B   0.00% │ ├╴3: bool
+     1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+     8 B   0.01% │ ├╴start: usize
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -82,7 +103,8 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
@@ -95,28 +117,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.08% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.15% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.06% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.61% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.03% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_619 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -103,6 +103,7 @@ expression: output
    108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 2_414 B   5.41% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.41% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.13% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.20% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.20% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.17% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -125,9 +125,9 @@ expression: output
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -103,6 +103,7 @@ expression: output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.28% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.28% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63175 B ⏺
+63_103 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@aarch64.snap
@@ -1,5 +1,0 @@
----
-source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: depth_output
----
-62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_619 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: output
+expression: depth_output
 ---
-62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_103 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,10 +46,8 @@ expression: output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
-     6 B   0.01% │ ├╴: str
-    12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
-     4 B   0.01% │ ├╴: i32
+    16 B   0.03% ├╴reference: &str
+     8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
@@ -60,40 +58,19 @@ expression: output
     28 B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
     42 B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
     38 B   0.06% ├╴tuple2: (i32, alloc::string::String)
-     4 B   0.01% │ ├╴0: i32 [4B]
-    30 B   0.05% │ ╰╴1: alloc::string::String
     43 B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
-     4 B   0.01% │ ├╴0: i32 [4B]
-    27 B   0.04% │ ├╴1: alloc::string::String
-     8 B   0.01% │ ╰╴2: f64
     43 B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
-     4 B   0.01% │ ├╴0: i32
-    27 B   0.04% │ ├╴1: alloc::string::String
-     8 B   0.01% │ ├╴2: f64
-     1 B   0.00% │ ╰╴3: bool [3B]
     43 B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
-     4 B   0.01% │ ├╴0: i32
-    27 B   0.04% │ ├╴1: alloc::string::String
-     8 B   0.01% │ ├╴2: f64
-     1 B   0.00% │ ├╴3: bool
-     1 B   0.00% │ ╰╴4: u8 [2B]
     16 B   0.03% ├╴range: core::ops::range::Range<usize>
-     8 B   0.01% │ ├╴start: usize
-     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-     8 B   0.01% │ ╰╴start: usize
     24 B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
-     8 B   0.01% │ ├╴start: usize
-     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
-     8 B   0.01% │ ╰╴end: usize
      8 B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
-     8 B   0.01% │ ╰╴end: usize
      4 B   0.01% ├╴cell: core::cell::Cell<i32>
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -105,14 +82,13 @@ expression: output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
-    25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
-     9 B   0.01% │ ├╴: std::path::Path
+    16 B   0.03% ├╴path: &std::path::Path
     33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
-    25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
-     9 B   0.01% │ ├╴: std::ffi::os_str::OsStr
+    16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
      8 B   0.01% ├╴fn_ptr2: fn(i32, i32) -> i32
@@ -120,28 +96,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.08% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.65% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.15% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.06% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.61% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.03% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_619 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -82,6 +82,7 @@ expression: depth_output
    108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,28 +96,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 2_414 B   5.41% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.41% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.13% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.20% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.20% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.17% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -82,6 +82,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,28 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.28% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.28% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -104,9 +104,9 @@ expression: depth_output
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_103 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -91,7 +91,7 @@ expression: depth_output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,8 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path
@@ -116,28 +117,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.08% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.15% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.06% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.61% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.03% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_527 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_619 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -103,6 +103,7 @@ expression: depth_output
    108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+     8 B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+     8 B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   688 B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 2_414 B   5.41% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.41% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.13% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.20% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.20% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.17% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62_987 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -103,6 +103,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.28% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.28% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_175 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -125,9 +125,9 @@ expression: depth_output
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: depth_output
+expression: output
 ---
-62915 B ⏺
+63103 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -58,19 +58,40 @@ expression: depth_output
    28 B ├╴slice
    42 B ├╴slice_str
    38 B ├╴tuple2
+    4 B │ ├╴0 [4B]
+   30 B │ ╰╴1
    43 B ├╴tuple3
+    4 B │ ├╴0 [4B]
+   27 B │ ├╴1
+    8 B │ ╰╴2
    43 B ├╴tuple4
+    4 B │ ├╴0
+   27 B │ ├╴1
+    8 B │ ├╴2
+    1 B │ ╰╴3 [3B]
    43 B ├╴tuple5
+    4 B │ ├╴0
+   27 B │ ├╴1
+    8 B │ ├╴2
+    1 B │ ├╴3
+    1 B │ ╰╴4 [2B]
    16 B ├╴range
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_from
+    8 B │ ╰╴start
    24 B ├╴range_inclusive
+    8 B │ ├╴start
+    8 B │ ╰╴end
     8 B ├╴range_to
+    8 B │ ╰╴end
     8 B ├╴range_to_inclusive
+    8 B │ ╰╴end
     4 B ├╴cell
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
    35 B ├╴once_cell
-   16 B ├╴mutex
+   12 B ├╴mutex
    46 B ├╴rw_lock
    76 B ├╴hash_set
   157 B ├╴hash_set_str
@@ -82,7 +103,8 @@ expression: depth_output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
-    0 B ├╴build_hasher [10B]
+   72 B ├╴linked_list
+    0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
    16 B ├╴path
@@ -102,6 +124,7 @@ expression: depth_output
     8 B ├╴rc
    92 B ├╴vec_deque_nested
    84 B ├╴binary_heap_nested
+  116 B ├╴linked_list_nested
    16 B ├╴mutex_guard
    16 B ├╴rw_lock_read_guard
    16 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-44527 B ⏺
+44619 B ⏺
     0 B ├╴unit
-    1 B ├╴boolean [14B]
+    1 B ├╴boolean [6B]
     4 B ├╴character
     4 B ├╴f32_val
     8 B ├╴f64_val
@@ -103,6 +103,7 @@ expression: output
   108 B ├╴btree_map_copy
    20 B ├╴vec_deque
    20 B ├╴binary_heap
+   36 B ├╴linked_list
     0 B ├╴build_hasher
    16 B ├╴random_state
    21 B ├╴path_buf
@@ -123,6 +124,7 @@ expression: output
     4 B ├╴rc
    52 B ├╴vec_deque_nested
    48 B ├╴binary_heap_nested
+   64 B ├╴linked_list_nested
     8 B ├╴mutex_guard
     8 B ├╴rw_lock_read_guard
     8 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-62987 B ⏺
+63175 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -103,6 +103,7 @@ expression: output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
+   72 B ├╴linked_list
     0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
@@ -123,6 +124,7 @@ expression: output
     8 B ├╴rc
    92 B ├╴vec_deque_nested
    84 B ├╴binary_heap_nested
+  116 B ├╴linked_list_nested
    16 B ├╴mutex_guard
    16 B ├╴rw_lock_read_guard
    16 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63175 B ⏺
+63103 B ⏺

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44527 B ⏺
+44619 B ⏺

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62915 B ⏺
+63103 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -58,40 +58,19 @@ expression: depth_output
    28 B ├╴slice
    42 B ├╴slice_str
    38 B ├╴tuple2
-    4 B │ ├╴0 [4B]
-   30 B │ ╰╴1
    43 B ├╴tuple3
-    4 B │ ├╴0 [4B]
-   27 B │ ├╴1
-    8 B │ ╰╴2
    43 B ├╴tuple4
-    4 B │ ├╴0
-   27 B │ ├╴1
-    8 B │ ├╴2
-    1 B │ ╰╴3 [3B]
    43 B ├╴tuple5
-    4 B │ ├╴0
-   27 B │ ├╴1
-    8 B │ ├╴2
-    1 B │ ├╴3
-    1 B │ ╰╴4 [2B]
    16 B ├╴range
-    8 B │ ├╴start
-    8 B │ ╰╴end
     8 B ├╴range_from
-    8 B │ ╰╴start
    24 B ├╴range_inclusive
-    8 B │ ├╴start
-    8 B │ ╰╴end
     8 B ├╴range_to
-    8 B │ ╰╴end
     8 B ├╴range_to_inclusive
-    8 B │ ╰╴end
     4 B ├╴cell
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
    35 B ├╴once_cell
-   16 B ├╴mutex
+   12 B ├╴mutex
    46 B ├╴rw_lock
    76 B ├╴hash_set
   157 B ├╴hash_set_str
@@ -103,7 +82,8 @@ expression: depth_output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
-    0 B ├╴build_hasher [10B]
+   72 B ├╴linked_list
+    0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
    16 B ├╴path
@@ -123,6 +103,7 @@ expression: depth_output
     8 B ├╴rc
    92 B ├╴vec_deque_nested
    84 B ├╴binary_heap_nested
+  116 B ├╴linked_list_nested
    16 B ├╴mutex_guard
    16 B ├╴rw_lock_read_guard
    16 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44527 B ⏺
+44619 B ⏺
     0 B ├╴unit
-    1 B ├╴boolean [14B]
+    1 B ├╴boolean [6B]
     4 B ├╴character
     4 B ├╴f32_val
     8 B ├╴f64_val
@@ -82,6 +82,7 @@ expression: depth_output
   108 B ├╴btree_map_copy
    20 B ├╴vec_deque
    20 B ├╴binary_heap
+   36 B ├╴linked_list
     0 B ├╴build_hasher
    16 B ├╴random_state
    21 B ├╴path_buf
@@ -102,6 +103,7 @@ expression: depth_output
     4 B ├╴rc
    52 B ├╴vec_deque_nested
    48 B ├╴binary_heap_nested
+   64 B ├╴linked_list_nested
     8 B ├╴mutex_guard
     8 B ├╴rw_lock_read_guard
     8 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62987 B ⏺
+63175 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -82,6 +82,7 @@ expression: depth_output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
+   72 B ├╴linked_list
     0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
@@ -102,6 +103,7 @@ expression: depth_output
     8 B ├╴rc
    92 B ├╴vec_deque_nested
    84 B ├╴binary_heap_nested
+  116 B ├╴linked_list_nested
    16 B ├╴mutex_guard
    16 B ├╴rw_lock_read_guard
    16 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: output
+expression: depth_output
 ---
-62915 B ⏺
+63103 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -91,7 +91,7 @@ expression: output
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
    35 B ├╴once_cell
-   16 B ├╴mutex
+   12 B ├╴mutex
    46 B ├╴rw_lock
    76 B ├╴hash_set
   157 B ├╴hash_set_str
@@ -103,7 +103,8 @@ expression: output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
-    0 B ├╴build_hasher [10B]
+   72 B ├╴linked_list
+    0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
    16 B ├╴path
@@ -123,6 +124,7 @@ expression: output
     8 B ├╴rc
    92 B ├╴vec_deque_nested
    84 B ├╴binary_heap_nested
+  116 B ├╴linked_list_nested
    16 B ├╴mutex_guard
    16 B ├╴rw_lock_read_guard
    16 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44527 B ⏺
+44619 B ⏺
     0 B ├╴unit
-    1 B ├╴boolean [14B]
+    1 B ├╴boolean [6B]
     4 B ├╴character
     4 B ├╴f32_val
     8 B ├╴f64_val
@@ -103,6 +103,7 @@ expression: depth_output
   108 B ├╴btree_map_copy
    20 B ├╴vec_deque
    20 B ├╴binary_heap
+   36 B ├╴linked_list
     0 B ├╴build_hasher
    16 B ├╴random_state
    21 B ├╴path_buf
@@ -123,6 +124,7 @@ expression: depth_output
     4 B ├╴rc
    52 B ├╴vec_deque_nested
    48 B ├╴binary_heap_nested
+   64 B ├╴linked_list_nested
     8 B ├╴mutex_guard
     8 B ├╴rw_lock_read_guard
     8 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62987 B ⏺
+63175 B ⏺
     0 B ├╴unit
     1 B ├╴boolean
     4 B ├╴character
@@ -103,6 +103,7 @@ expression: depth_output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
+   72 B ├╴linked_list
     0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
@@ -123,6 +124,7 @@ expression: depth_output
     8 B ├╴rc
    92 B ├╴vec_deque_nested
    84 B ├╴binary_heap_nested
+  116 B ├╴linked_list_nested
    16 B ├╴mutex_guard
    16 B ├╴rw_lock_read_guard
    16 B ├╴rw_lock_write_guard

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-62_915 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -46,8 +46,10 @@ expression: output
      0 B   0.00% ├╴phantom_pinned: core::marker::PhantomPinned
      0 B   0.00% ├╴phantom_data: core::marker::PhantomData<i32>
     29 B   0.05% ├╴string: alloc::string::String
-    16 B   0.03% ├╴reference: &str
-     8 B   0.01% ├╴mut_reference: &mut i32
+    22 B   0.03% ├╴reference: &str @ 0x[ADDR_1]
+     6 B   0.01% │ ├╴: str
+    12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
+     4 B   0.01% │ ├╴: i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
@@ -91,7 +93,7 @@ expression: output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,12 +105,15 @@ expression: output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
-    16 B   0.03% ├╴path: &std::path::Path
+    25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
+     9 B   0.01% │ ├╴: std::path::Path
     33 B   0.05% ├╴os_string: std::ffi::os_str::OsString
-    16 B   0.03% ├╴os_str: &std::ffi::os_str::OsStr
+    25 B   0.04% ├╴os_str: &std::ffi::os_str::OsStr @ 0x[ADDR_4]
+     9 B   0.01% │ ├╴: std::ffi::os_str::OsStr
      8 B   0.01% ├╴fn_ptr0: fn() -> i32
      8 B   0.01% ├╴fn_ptr1: fn(i32) -> i32
      8 B   0.01% ├╴fn_ptr2: fn(i32, i32) -> i32
@@ -116,28 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    16 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    16 B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.03% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -105,6 +105,7 @@ expression: output
    108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -120,28 +121,29 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.47% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.46% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.14% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.21% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.21% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.19% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -105,6 +105,7 @@ expression: output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -120,28 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.11% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.16% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.07% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.63% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -129,9 +129,9 @@ expression: output
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63175 B ⏺
+63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64.snap
@@ -1,5 +1,0 @@
----
-source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: depth_output
----
-62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -70,7 +70,7 @@ expression: depth_output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -82,7 +82,8 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
@@ -95,28 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.65% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.03% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -82,6 +82,7 @@ expression: depth_output
    108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,28 +96,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.47% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.46% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.14% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.21% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.21% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.19% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -104,9 +104,9 @@ expression: depth_output
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -82,6 +82,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,28 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.11% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.16% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.07% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.63% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62_961 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -93,7 +93,7 @@ expression: depth_output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -105,7 +105,8 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]
@@ -120,28 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.13% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   696 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_208 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.65% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
      8 B   0.01% ├╴i64_val: i64
     16 B   0.03% ├╴i128_val: i128
      8 B   0.01% ├╴isize_val: isize
-     1 B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-     1 B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-     2 B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-     4 B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-     8 B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-     8 B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-     1 B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-     2 B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-     4 B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-     8 B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-     8 B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+     1 B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+     1 B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+     2 B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+     4 B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+     8 B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+     8 B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+     1 B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+     2 B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+     4 B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+     8 B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+     8 B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
      1 B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
      2 B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
      4 B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_573 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
-     1 B   0.00% ├╴boolean: bool [14B]
+     1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
      4 B   0.01% ├╴f32_val: f32
      8 B   0.02% ├╴f64_val: f64
@@ -105,6 +105,7 @@ expression: depth_output
    108 B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     20 B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     20 B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    36 B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
     16 B   0.04% ├╴random_state: std::hash::random::RandomState
     21 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -120,28 +121,29 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.47% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.46% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 2_414 B   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 2_414 B   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 3_628 B   8.14% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     12 B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_092 B   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 1_884 B   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.21% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.21% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.19% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_033 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -105,6 +105,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+    72 B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
      0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
@@ -120,28 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.11% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.10% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+   116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
     16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
     22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
     28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-   704 B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+   704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_216 B   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_966 B   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_966 B   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.65% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
- 1_404 B   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+ 1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
- 2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.16% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.07% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.63% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+ 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -129,9 +129,9 @@ expression: depth_output
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: depth_output
+expression: output
 ---
-62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.10 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -58,19 +58,40 @@ expression: depth_output
    28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
+    4  B   0.01% │ ├╴0: i32 [4B]
+   30  B   0.05% │ ╰╴1: alloc::string::String
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
+    4  B   0.01% │ ├╴0: i32 [4B]
+   27  B   0.04% │ ├╴1: alloc::string::String
+    8  B   0.01% │ ╰╴2: f64
    43  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
+    4  B   0.01% │ ├╴0: i32
+   27  B   0.04% │ ├╴1: alloc::string::String
+    8  B   0.01% │ ├╴2: f64
+    1  B   0.00% │ ╰╴3: bool [3B]
    43  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
+    4  B   0.01% │ ├╴0: i32
+   27  B   0.04% │ ├╴1: alloc::string::String
+    8  B   0.01% │ ├╴2: f64
+    1  B   0.00% │ ├╴3: bool
+    1  B   0.00% │ ╰╴4: u8 [2B]
    16  B   0.03% ├╴range: core::ops::range::Range<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
+    8  B   0.01% │ ╰╴start: usize
    24  B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
+    8  B   0.01% │ ├╴start: usize
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
+    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
+    8  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-   16  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+   12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
    76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
   157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -82,7 +103,8 @@ expression: depth_output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+   72  B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
@@ -95,28 +117,29 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.08% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+  116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  696  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  696  B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.208 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.958 kB   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.958 kB   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.708 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.208 kB   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.958 kB   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.958 kB   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.708 kB  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-6.406 kB  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-6.346 kB  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10.48 kB  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+2.184 kB   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.15% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.06% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.61% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: output
     8  B   0.01% ├╴i64_val: i64
    16  B   0.03% ├╴i128_val: i128
     8  B   0.01% ├╴isize_val: isize
-    1  B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-    1  B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-    2  B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-    4  B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-    8  B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-    8  B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-    1  B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-    2  B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-    4  B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-    8  B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-    8  B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+    1  B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+    1  B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+    2  B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+    4  B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+    8  B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+    8  B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+    1  B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+    2  B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+    4  B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+    8  B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+    8  B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
     1  B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
     2  B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
     4  B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.62 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
-    1  B   0.00% ├╴boolean: bool [14B]
+    1  B   0.00% ├╴boolean: bool [6B]
     4  B   0.01% ├╴character: char
     4  B   0.01% ├╴f32_val: f32
     8  B   0.02% ├╴f64_val: f64
@@ -103,6 +103,7 @@ expression: output
   108  B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    20  B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    20  B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   36  B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
    16  B   0.04% ├╴random_state: std::hash::random::RandomState
    21  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: output
     4  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     8  B   0.02% ├╴layout: core::alloc::layout::Layout
     4  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.232 kB  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.228 kB  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.232 kB  18.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.228 kB  18.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    24  B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     4  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     4  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    52  B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    48  B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    8  B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   64  B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    8  B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    32  B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  688  B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  688  B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    32  B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
 1.200 kB   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-2.414 kB   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-2.414 kB   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-3.628 kB   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+2.414 kB   5.41% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+2.414 kB   5.41% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+3.628 kB   8.13% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    12  B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
 1.092 kB   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    12  B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.884 kB   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-3.658 kB   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-3.658 kB   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-5.432 kB  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+1.884 kB   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+3.658 kB   8.20% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+3.658 kB   8.20% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+5.432 kB  12.17% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    64  B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -103,6 +103,7 @@ expression: output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   72  B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+  116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  704  B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  704  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.216 kB   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.966 kB   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.966 kB   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.716 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.216 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.966 kB   6.28% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.966 kB   6.28% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.716 kB  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-6.406 kB  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-6.346 kB  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10.48 kB  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+2.184 kB   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -125,9 +125,9 @@ expression: output
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
   116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
   704  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62915 B ⏺
+63.10 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@aarch64.snap
@@ -1,5 +1,0 @@
----
-source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: depth_output
----
-62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.62 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64-linux.snap
@@ -1,8 +1,8 @@
 ---
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
-expression: output
+expression: depth_output
 ---
-62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.10 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -58,40 +58,19 @@ expression: output
    28  B   0.04% ├╴slice: alloc::boxed::Box<[u32]>
    42  B   0.07% ├╴slice_str: alloc::boxed::Box<[alloc::string::String]>
    38  B   0.06% ├╴tuple2: (i32, alloc::string::String)
-    4  B   0.01% │ ├╴0: i32 [4B]
-   30  B   0.05% │ ╰╴1: alloc::string::String
    43  B   0.07% ├╴tuple3: (i32, alloc::string::String, f64)
-    4  B   0.01% │ ├╴0: i32 [4B]
-   27  B   0.04% │ ├╴1: alloc::string::String
-    8  B   0.01% │ ╰╴2: f64
    43  B   0.07% ├╴tuple4: (i32, alloc::string::String, f64, bool)
-    4  B   0.01% │ ├╴0: i32
-   27  B   0.04% │ ├╴1: alloc::string::String
-    8  B   0.01% │ ├╴2: f64
-    1  B   0.00% │ ╰╴3: bool [3B]
    43  B   0.07% ├╴tuple5: (i32, alloc::string::String, f64, bool, u8)
-    4  B   0.01% │ ├╴0: i32
-   27  B   0.04% │ ├╴1: alloc::string::String
-    8  B   0.01% │ ├╴2: f64
-    1  B   0.00% │ ├╴3: bool
-    1  B   0.00% │ ╰╴4: u8 [2B]
    16  B   0.03% ├╴range: core::ops::range::Range<usize>
-    8  B   0.01% │ ├╴start: usize
-    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_from: core::ops::range::RangeFrom<usize>
-    8  B   0.01% │ ╰╴start: usize
    24  B   0.04% ├╴range_inclusive: core::ops::range::RangeInclusive<usize>
-    8  B   0.01% │ ├╴start: usize
-    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to: core::ops::range::RangeTo<usize>
-    8  B   0.01% │ ╰╴end: usize
     8  B   0.01% ├╴range_to_inclusive: core::ops::range::RangeToInclusive<usize>
-    8  B   0.01% │ ╰╴end: usize
     4  B   0.01% ├╴cell: core::cell::Cell<i32>
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-   16  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+   12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
    76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
   157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +82,8 @@ expression: output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+   72  B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
@@ -116,28 +96,29 @@ expression: output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.08% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+  116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  696  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  696  B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.208 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.958 kB   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.958 kB   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.708 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.208 kB   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.958 kB   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.958 kB   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.708 kB  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-6.406 kB  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-6.346 kB  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10.48 kB  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+2.184 kB   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.15% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.06% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.61% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
     8  B   0.01% ├╴i64_val: i64
    16  B   0.03% ├╴i128_val: i128
     8  B   0.01% ├╴isize_val: isize
-    1  B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-    1  B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-    2  B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-    4  B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-    8  B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-    8  B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-    1  B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-    2  B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-    4  B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-    8  B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-    8  B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+    1  B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+    1  B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+    2  B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+    4  B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+    8  B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+    8  B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+    1  B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+    2  B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+    4  B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+    8  B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+    8  B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
     1  B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
     2  B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
     4  B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.62 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
-    1  B   0.00% ├╴boolean: bool [14B]
+    1  B   0.00% ├╴boolean: bool [6B]
     4  B   0.01% ├╴character: char
     4  B   0.01% ├╴f32_val: f32
     8  B   0.02% ├╴f64_val: f64
@@ -82,6 +82,7 @@ expression: depth_output
   108  B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    20  B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    20  B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   36  B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
    16  B   0.04% ├╴random_state: std::hash::random::RandomState
    21  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,28 +96,29 @@ expression: depth_output
     4  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     8  B   0.02% ├╴layout: core::alloc::layout::Layout
     4  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.232 kB  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.228 kB  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.232 kB  18.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.228 kB  18.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    24  B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     4  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     4  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    52  B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    48  B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    8  B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   64  B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    8  B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    32  B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  688  B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  688  B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    32  B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
 1.200 kB   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-2.414 kB   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-2.414 kB   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-3.628 kB   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+2.414 kB   5.41% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+2.414 kB   5.41% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+3.628 kB   8.13% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    12  B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
 1.092 kB   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    12  B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.884 kB   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-3.658 kB   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-3.658 kB   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-5.432 kB  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+1.884 kB   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+3.658 kB   8.20% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+3.658 kB   8.20% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+5.432 kB  12.17% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    64  B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -82,6 +82,7 @@ expression: depth_output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   72  B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -95,28 +96,29 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+  116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  704  B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  704  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.216 kB   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.966 kB   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.966 kB   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.716 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.216 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.966 kB   6.28% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.966 kB   6.28% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.716 kB  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-6.406 kB  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-6.346 kB  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10.48 kB  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+2.184 kB   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -104,9 +104,9 @@ expression: depth_output
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
   116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
   704  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-linux.snap
@@ -20,17 +20,17 @@ expression: depth_output
     8  B   0.01% ├╴i64_val: i64
    16  B   0.03% ├╴i128_val: i128
     8  B   0.01% ├╴isize_val: isize
-    1  B   0.00% ├╴atomic_bool: core::sync::atomic::Atomic<bool>
-    1  B   0.00% ├╴atomic_i8: core::sync::atomic::Atomic<i8>
-    2  B   0.00% ├╴atomic_i16: core::sync::atomic::Atomic<i16>
-    4  B   0.01% ├╴atomic_i32: core::sync::atomic::Atomic<i32>
-    8  B   0.01% ├╴atomic_i64: core::sync::atomic::Atomic<i64>
-    8  B   0.01% ├╴atomic_isize: core::sync::atomic::Atomic<isize>
-    1  B   0.00% ├╴atomic_u8: core::sync::atomic::Atomic<u8>
-    2  B   0.00% ├╴atomic_u16: core::sync::atomic::Atomic<u16>
-    4  B   0.01% ├╴atomic_u32: core::sync::atomic::Atomic<u32>
-    8  B   0.01% ├╴atomic_u64: core::sync::atomic::Atomic<u64>
-    8  B   0.01% ├╴atomic_usize: core::sync::atomic::Atomic<usize>
+    1  B   0.00% ├╴atomic_bool: core::sync::atomic::AtomicBool
+    1  B   0.00% ├╴atomic_i8: core::sync::atomic::AtomicI8
+    2  B   0.00% ├╴atomic_i16: core::sync::atomic::AtomicI16
+    4  B   0.01% ├╴atomic_i32: core::sync::atomic::AtomicI32
+    8  B   0.01% ├╴atomic_i64: core::sync::atomic::AtomicI64
+    8  B   0.01% ├╴atomic_isize: core::sync::atomic::AtomicIsize
+    1  B   0.00% ├╴atomic_u8: core::sync::atomic::AtomicU8
+    2  B   0.00% ├╴atomic_u16: core::sync::atomic::AtomicU16
+    4  B   0.01% ├╴atomic_u32: core::sync::atomic::AtomicU32
+    8  B   0.01% ├╴atomic_u64: core::sync::atomic::AtomicU64
+    8  B   0.01% ├╴atomic_usize: core::sync::atomic::AtomicUsize
     1  B   0.00% ├╴nz_i8: core::num::nonzero::NonZero<i8>
     2  B   0.00% ├╴nz_i16: core::num::nonzero::NonZero<i16>
     4  B   0.01% ├╴nz_i32: core::num::nonzero::NonZero<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62.91 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.10 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -91,7 +91,7 @@ expression: depth_output
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-   16  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+   12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
    76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
   157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,8 @@ expression: depth_output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+   72  B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
+    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path
@@ -116,28 +117,29 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.14% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.12% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.10% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.08% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+  116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  696  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  696  B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.208 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.958 kB   6.29% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.958 kB   6.29% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.708 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.208 kB   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.958 kB   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.958 kB   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.708 kB  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-6.406 kB  10.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-6.346 kB  10.09% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10.48 kB  16.66% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+2.184 kB   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.15% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.06% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.61% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86.snap
@@ -2,9 +2,9 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44.53 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+44.62 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
-    1  B   0.00% ├╴boolean: bool [14B]
+    1  B   0.00% ├╴boolean: bool [6B]
     4  B   0.01% ├╴character: char
     4  B   0.01% ├╴f32_val: f32
     8  B   0.02% ├╴f64_val: f64
@@ -103,6 +103,7 @@ expression: depth_output
   108  B   0.24% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    20  B   0.04% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    20  B   0.04% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   36  B   0.08% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher>
    16  B   0.04% ├╴random_state: std::hash::random::RandomState
    21  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: depth_output
     4  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     8  B   0.02% ├╴layout: core::alloc::layout::Layout
     4  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.232 kB  18.49% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.228 kB  18.48% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.232 kB  18.45% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.228 kB  18.44% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    24  B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     4  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     4  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    52  B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    48  B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
-    8  B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-    8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-    8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   64  B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
+    8  B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    8  B   0.02% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    8  B   0.02% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    32  B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  688  B   1.55% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  688  B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    32  B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
 1.200 kB   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-2.414 kB   5.42% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-2.414 kB   5.42% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-3.628 kB   8.15% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+2.414 kB   5.41% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+2.414 kB   5.41% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+3.628 kB   8.13% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    12  B   0.03% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
 1.092 kB   2.45% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    12  B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-1.884 kB   4.23% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-3.658 kB   8.22% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-3.658 kB   8.22% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-5.432 kB  12.20% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+1.884 kB   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+3.658 kB   8.20% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+3.658 kB   8.20% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+5.432 kB  12.17% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    64  B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -125,9 +125,9 @@ expression: depth_output
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
   116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
-   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
-   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
+   16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+   16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+   16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
   704  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-62.99 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
+63.17 kB 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct<'_>
     0  B   0.00% ├╴unit: ()
     1  B   0.00% ├╴boolean: bool
     4  B   0.01% ├╴character: char
@@ -103,6 +103,7 @@ expression: depth_output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
+   72  B   0.11% ├╴linked_list: alloc::collections::linked_list::LinkedList<u32>
     0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
@@ -116,28 +117,29 @@ expression: depth_output
     8  B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
    16  B   0.03% ├╴layout: core::alloc::layout::Layout
     8  B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
-8.264 kB  13.12% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
-8.256 kB  13.11% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.264 kB  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+8.256 kB  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
    36  B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
     8  B   0.01% ├╴arc: alloc::sync::Arc<i32>
     8  B   0.01% ├╴rc: alloc::rc::Rc<i32>
    92  B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
    84  B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
+  116  B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
    16  B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<'_, i32>
    16  B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<'_, alloc::string::String>
    16  B   0.03% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<'_, alloc::string::String>
    48  B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
-  704  B   1.12% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
+  704  B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
    48  B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
-1.216 kB   1.93% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
-3.966 kB   6.30% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
-3.966 kB   6.30% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
-6.716 kB  10.66% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+1.216 kB   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+3.966 kB   6.28% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+3.966 kB   6.28% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+6.716 kB  10.63% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
    24  B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
-1.404 kB   2.23% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
+1.404 kB   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
    24  B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
-2.184 kB   3.47% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
-6.406 kB  10.17% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
-6.346 kB  10.08% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10.48 kB  16.64% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+2.184 kB   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
+6.406 kB  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+6.346 kB  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10.48 kB  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
    72  B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/test_all_types_mem_dbg_insta.rs
+++ b/mem_dbg/tests/test_all_types_mem_dbg_insta.rs
@@ -30,6 +30,17 @@ fn redact_addresses(s: &str) -> String {
     .to_string()
 }
 
+/// Normalize type-name rendering that changed across Rust toolchains.
+fn normalize_type_names(s: String) -> String {
+    s.replace(
+        "all_types_helper::AllTypesStruct<'_>",
+        "all_types_helper::AllTypesStruct",
+    )
+    .replace("MutexGuard<'_, ", "MutexGuard<")
+    .replace("RwLockReadGuard<'_, ", "RwLockReadGuard<")
+    .replace("RwLockWriteGuard<'_, ", "RwLockWriteGuard<")
+}
+
 #[test]
 #[cfg_attr(miri, ignore)] // too slow under miri
 fn test_all_types_mem_dbg_snapshot() {
@@ -57,7 +68,7 @@ fn test_all_types_mem_dbg_snapshot() {
                 .expect("mem_dbg_on failed");
             output
         });
-        let output = redact_addresses(&output);
+        let output = normalize_type_names(redact_addresses(&output));
         with_settings!({snapshot_suffix => snapshot_suffix}, {
             assert_snapshot!(name, output);
         });
@@ -69,7 +80,7 @@ fn test_all_types_mem_dbg_snapshot() {
                     .expect("mem_dbg_depth_on failed");
                 output
             });
-            let depth_output = redact_addresses(&depth_output);
+            let depth_output = normalize_type_names(redact_addresses(&depth_output));
             with_settings!({snapshot_suffix => snapshot_suffix}, {
                 assert_snapshot!(format!("{name}_depth_{depth}"), depth_output);
             });

--- a/mem_dbg/tests/test_all_types_mem_dbg_insta.rs
+++ b/mem_dbg/tests/test_all_types_mem_dbg_insta.rs
@@ -41,9 +41,13 @@ fn test_all_types_mem_dbg_snapshot() {
         ("follow_refs", DbgFlags::default() | DbgFlags::FOLLOW_REFS),
     ];
 
-    // Use architecture-specific snapshots since memory sizes differ
-    // (e.g., GROUP_WIDTH is 16 on x86_64 with SSE2, 8 on ARM64)
-    let arch = std::env::consts::ARCH;
+    // Use target-specific snapshots since memory sizes differ by architecture
+    // and aarch64 differs between Linux and Darwin.
+    let snapshot_suffix = match (std::env::consts::ARCH, std::env::consts::OS) {
+        ("aarch64", "linux") => "aarch64-linux",
+        ("aarch64", "macos") => "aarch64-darwin",
+        (arch, _) => arch,
+    };
 
     for (name, flags) in combinations {
         let output = run_all_types_test(|all_types| {
@@ -54,7 +58,7 @@ fn test_all_types_mem_dbg_snapshot() {
             output
         });
         let output = redact_addresses(&output);
-        with_settings!({snapshot_suffix => arch}, {
+        with_settings!({snapshot_suffix => snapshot_suffix}, {
             assert_snapshot!(name, output);
         });
         for depth in 0..3 {
@@ -66,7 +70,7 @@ fn test_all_types_mem_dbg_snapshot() {
                 output
             });
             let depth_output = redact_addresses(&depth_output);
-            with_settings!({snapshot_suffix => arch}, {
+            with_settings!({snapshot_suffix => snapshot_suffix}, {
                 assert_snapshot!(format!("{name}_depth_{depth}"), depth_output);
             });
         }

--- a/mem_dbg/tests/test_linked_list.rs
+++ b/mem_dbg/tests/test_linked_list.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "std")]
+use mem_dbg::*;
+use std::collections::LinkedList;
+
+#[test]
+fn test_linked_list_empty() {
+    let l: LinkedList<u32> = LinkedList::new();
+    assert_eq!(
+        l.mem_size(SizeFlags::default()),
+        core::mem::size_of::<LinkedList<u32>>()
+    );
+}
+
+#[test]
+fn test_linked_list_flat_elements() {
+    let mut l: LinkedList<u32> = LinkedList::new();
+    l.push_back(1);
+    l.push_back(2);
+    l.push_back(3);
+
+    let expected = core::mem::size_of::<LinkedList<u32>>()
+        + l.len() * core::mem::size_of::<LinkedListNode<u32>>();
+    assert_eq!(l.mem_size(SizeFlags::default()), expected);
+}
+
+#[test]
+fn test_linked_list_capacity_matches_default() {
+    // LinkedList allocates per node and has no reserved spare capacity, so
+    // `SizeFlags::CAPACITY` must return the same value as the default flags.
+    let mut l: LinkedList<u32> = LinkedList::new();
+    l.push_back(10);
+    l.push_back(20);
+    assert_eq!(
+        l.mem_size(SizeFlags::default()),
+        l.mem_size(SizeFlags::CAPACITY)
+    );
+}
+
+#[test]
+fn test_linked_list_with_heap_elements() {
+    let mut l: LinkedList<String> = LinkedList::new();
+    l.push_back("hello".to_string());
+    l.push_back("world".to_string());
+
+    let per_node_overhead =
+        core::mem::size_of::<LinkedListNode<String>>() - core::mem::size_of::<String>();
+    let inner: usize = l
+        .iter()
+        .map(|s| <String as MemSize>::mem_size(s, SizeFlags::default()) + per_node_overhead)
+        .sum();
+    assert_eq!(
+        l.mem_size(SizeFlags::default()),
+        core::mem::size_of::<LinkedList<String>>() + inner
+    );
+}
+
+#[test]
+fn test_linked_list_aligned_element_node_size() {
+    // Sanity check that the mirror struct correctly accounts for elements
+    // whose alignment exceeds pointer alignment.
+    #[repr(align(32))]
+    #[derive(Clone, Copy)]
+    #[allow(dead_code)]
+    struct Aligned32(u8);
+
+    impl FlatType for Aligned32 {
+        type Flat = True;
+    }
+    impl MemSize for Aligned32 {
+        fn mem_size_rec(
+            &self,
+            _flags: SizeFlags,
+            _refs: &mut mem_dbg::HashMap<usize, usize>,
+        ) -> usize {
+            core::mem::size_of::<Self>()
+        }
+    }
+
+    let mut l: LinkedList<Aligned32> = LinkedList::new();
+    l.push_back(Aligned32(1));
+    l.push_back(Aligned32(2));
+
+    let expected = core::mem::size_of::<LinkedList<Aligned32>>()
+        + l.len() * core::mem::size_of::<LinkedListNode<Aligned32>>();
+    assert_eq!(l.mem_size(SizeFlags::default()), expected);
+}
+
+#[test]
+fn test_linked_list_mem_dbg() {
+    let mut l: LinkedList<u32> = LinkedList::new();
+    l.push_back(1);
+    l.push_back(2);
+    l.mem_dbg(DbgFlags::default()).unwrap();
+}
+
+#[test]
+fn test_linked_list_mem_dbg_depth() {
+    let mut l: LinkedList<u32> = LinkedList::new();
+    l.push_back(1);
+
+    for depth in 0..3 {
+        let result = l.mem_dbg_depth(depth, DbgFlags::default());
+        assert!(result.is_ok());
+    }
+}

--- a/mem_dbg/tests/test_linked_list.rs
+++ b/mem_dbg/tests/test_linked_list.rs
@@ -86,20 +86,73 @@ fn test_linked_list_aligned_element_node_size() {
 }
 
 #[test]
+fn test_linked_list_with_aligned_heap_elements() {
+    // Exercise the non-flat helper path when the element alignment exceeds
+    // pointer alignment, so node padding is part of the per-node overhead.
+    #[repr(align(32))]
+    #[derive(Clone)]
+    #[allow(dead_code)]
+    struct AlignedHeap {
+        data: Vec<u8>,
+    }
+
+    impl FlatType for AlignedHeap {
+        type Flat = False;
+    }
+    impl MemSize for AlignedHeap {
+        fn mem_size_rec(
+            &self,
+            flags: SizeFlags,
+            refs: &mut mem_dbg::HashMap<usize, usize>,
+        ) -> usize {
+            core::mem::size_of::<Self>()
+                + (<Vec<u8> as MemSize>::mem_size_rec(&self.data, flags, refs)
+                    - core::mem::size_of::<Vec<u8>>())
+        }
+    }
+
+    let mut l: LinkedList<AlignedHeap> = LinkedList::new();
+    l.push_back(AlignedHeap {
+        data: vec![1, 2, 3],
+    });
+    l.push_back(AlignedHeap {
+        data: vec![4, 5, 6, 7],
+    });
+
+    let per_node_overhead =
+        core::mem::size_of::<LinkedListNode<AlignedHeap>>() - core::mem::size_of::<AlignedHeap>();
+    let mut refs = mem_dbg::HashMap::new();
+    let inner: usize = l
+        .iter()
+        .map(|x| {
+            <AlignedHeap as MemSize>::mem_size_rec(x, SizeFlags::default(), &mut refs)
+                + per_node_overhead
+        })
+        .sum();
+    assert_eq!(
+        l.mem_size(SizeFlags::default()),
+        core::mem::size_of::<LinkedList<AlignedHeap>>() + inner
+    );
+}
+
+#[test]
 fn test_linked_list_mem_dbg() {
     let mut l: LinkedList<u32> = LinkedList::new();
     l.push_back(1);
     l.push_back(2);
-    l.mem_dbg(DbgFlags::default()).unwrap();
-}
-
-#[test]
-fn test_linked_list_mem_dbg_depth() {
-    let mut l: LinkedList<u32> = LinkedList::new();
-    l.push_back(1);
+    let expected_size = l.mem_size(SizeFlags::default());
 
     for depth in 0..3 {
-        let result = l.mem_dbg_depth(depth, DbgFlags::default());
-        assert!(result.is_ok());
+        let mut output = String::new();
+        l.mem_dbg_depth_on(&mut output, depth, DbgFlags::default())
+            .expect("mem_dbg_depth_on should not fail");
+        assert!(
+            output.contains("LinkedList"),
+            "output at depth {depth} missing type name: {output:?}"
+        );
+        assert!(
+            output.contains(&expected_size.to_string()),
+            "output at depth {depth} missing total size {expected_size}: {output:?}"
+        );
     }
 }


### PR DESCRIPTION
Adds `MemSize` and `MemDbg` for `LinkedList<T>`, available under both `no_std + alloc` and `std`.

Per-node accounting uses a layout-equivalent mirror of std's private `Node<T>` rather than a hand-rolled formula. `2 * size_of::<usize>() + size_of::<T>()` miscounts when `align_of::<T>() > align_of::<usize>()`: the compiler pads before `T` and rounds up to `T`'s alignment, so an `align(32)` `T` of size 32 lives in a 64-byte node, not 48. A mirror struct delegates layout to the compiler and matches `Node<T>` for any `T`. Same pattern as `RcInner` and `ArcInner`.

The mirror is `#[doc(hidden)] pub` and re-exported as `mem_dbg::LinkedListNode` so integration tests can compute expected sizes against the same definition. Not part of the stable public API.

`LinkedList<T>` has no reserved spare capacity, so `SizeFlags::CAPACITY` matches the default.