### PR TITLE
fix(tests): restore correct aarch64 insta snapshots (unblock build-aarch64 CI)

### DIFF
--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64.snap
@@ -91,7 +91,7 @@ expression: output
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,7 @@ expression: output
    128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.02% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_1@aarch64.snap
@@ -70,7 +70,7 @@ expression: depth_output
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -82,7 +82,7 @@ expression: depth_output
    128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.02% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64.snap
@@ -91,7 +91,7 @@ expression: depth_output
     16 B   0.02% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.05% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.11% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.23% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,7 @@ expression: depth_output
    128 B   0.18% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     48 B   0.07% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     40 B   0.06% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.02% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.02% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64.snap
@@ -91,7 +91,7 @@ expression: output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,7 @@ expression: output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_1@aarch64.snap
@@ -70,7 +70,7 @@ expression: depth_output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -82,7 +82,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64.snap
@@ -91,7 +91,7 @@ expression: depth_output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     16 B   0.03% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64.snap
@@ -91,7 +91,7 @@ expression: output
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
    35 B ├╴once_cell
-   16 B ├╴mutex
+   12 B ├╴mutex
    46 B ├╴rw_lock
    76 B ├╴hash_set
   157 B ├╴hash_set_str
@@ -103,7 +103,7 @@ expression: output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
-    0 B ├╴build_hasher [10B]
+    0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
    16 B ├╴path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_1@aarch64.snap
@@ -70,7 +70,7 @@ expression: depth_output
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
    35 B ├╴once_cell
-   16 B ├╴mutex
+   12 B ├╴mutex
    46 B ├╴rw_lock
    76 B ├╴hash_set
   157 B ├╴hash_set_str
@@ -82,7 +82,7 @@ expression: depth_output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
-    0 B ├╴build_hasher [10B]
+    0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
    16 B ├╴path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64.snap
@@ -91,7 +91,7 @@ expression: depth_output
    16 B ├╴ref_cell
     4 B ├╴unsafe_cell
    35 B ├╴once_cell
-   16 B ├╴mutex
+   12 B ├╴mutex
    46 B ├╴rw_lock
    76 B ├╴hash_set
   157 B ├╴hash_set_str
@@ -103,7 +103,7 @@ expression: depth_output
   128 B ├╴btree_map_copy
    36 B ├╴vec_deque
    32 B ├╴binary_heap
-    0 B ├╴build_hasher [10B]
+    0 B ├╴build_hasher [14B]
    16 B ├╴random_state
    33 B ├╴path_buf
    16 B ├╴path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64.snap
@@ -93,7 +93,7 @@ expression: output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -105,7 +105,7 @@ expression: output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64.snap
@@ -70,7 +70,7 @@ expression: depth_output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -82,7 +82,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64.snap
@@ -93,7 +93,7 @@ expression: depth_output
     16 B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
      4 B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
     35 B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-    16 B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+    12 B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
     46 B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
     76 B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
    157 B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -105,7 +105,7 @@ expression: depth_output
    128 B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
     36 B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
     32 B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+     0 B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
     16 B   0.03% ├╴random_state: std::hash::random::RandomState
     33 B   0.05% ├╴path_buf: std::path::PathBuf
     25 B   0.04% ├╴path: &std::path::Path @ 0x[ADDR_3]

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64.snap
@@ -91,7 +91,7 @@ expression: output
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-   16  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+   12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
    76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
   157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,7 @@ expression: output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_1@aarch64.snap
@@ -70,7 +70,7 @@ expression: depth_output
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-   16  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+   12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
    76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
   157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -82,7 +82,7 @@ expression: depth_output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64.snap
@@ -91,7 +91,7 @@ expression: depth_output
    16  B   0.03% ├╴ref_cell: core::cell::RefCell<i32>
     4  B   0.01% ├╴unsafe_cell: core::cell::UnsafeCell<i32>
    35  B   0.06% ├╴once_cell: core::cell::once::OnceCell<alloc::string::String>
-   16  B   0.03% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
+   12  B   0.02% ├╴mutex: std::sync::poison::mutex::Mutex<i32>
    46  B   0.07% ├╴rw_lock: std::sync::poison::rwlock::RwLock<alloc::string::String>
    76  B   0.12% ├╴hash_set: std::collections::hash::set::HashSet<i32>
   157  B   0.25% ├╴hash_set_str: std::collections::hash::set::HashSet<alloc::string::String>
@@ -103,7 +103,7 @@ expression: depth_output
   128  B   0.20% ├╴btree_map_copy: alloc::collections::btree::map::BTreeMap<i32, i32>
    36  B   0.06% ├╴vec_deque: alloc::collections::vec_deque::VecDeque<u32>
    32  B   0.05% ├╴binary_heap: alloc::collections::binary_heap::BinaryHeap<u32>
-    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [10B]
+    0  B   0.00% ├╴build_hasher: core::hash::BuildHasherDefault<std::hash::random::DefaultHasher> [14B]
    16  B   0.03% ├╴random_state: std::hash::random::RandomState
    33  B   0.05% ├╴path_buf: std::path::PathBuf
    16  B   0.03% ├╴path: &std::path::Path


### PR DESCRIPTION
## Summary

Restores the `@aarch64` insta snapshots, which were overwritten with **x86_64** values in 37bcdfb ("Fixed insta tests") and have broken the `build-aarch64` CI job on every commit and PR since.

The aarch64 snapshot wrongly recorded:

| field | committed (wrong, x86_64) | actual aarch64 |
|---|---|---|
| `mutex: std::sync::Mutex<i32>` | 16 B | **12 B** |
| `build_hasher: BuildHasherDefault<…>` | `[10B]` | **`[14B]`** |

`std::sync::Mutex<i32>` is 12 B on aarch64 vs 16 B on x86_64, so the snapshot can only ever match one architecture. The `build-aarch64` job was **green at 37bcdfb's parent (`1718dd1a`) and red at `37bcdfb`**.

## Fix

Regenerated all 15 `@aarch64` snapshots under qemu-aarch64 user emulation (`docker run --platform linux/arm64 rust:latest`, binfmt via `tonistiigi/binfmt`), with the same feature set the `build-aarch64` job uses:

```
INSTA_UPDATE=always cargo test --features std,derive,half,maligned,mmap-rs,rand \
  --test test_all_types_mem_dbg_insta
```

The regenerated files are **byte-identical** to the last-green (pre-37bcdfb) snapshots — i.e. this is equivalent to reverting only the snapshot edits 37bcdfb introduced, confirmed independently by regeneration rather than a blind revert.

## Verification

- `test_all_types_mem_dbg_insta` passes under emulated aarch64 (`2 passed`).
- Diff is value-only (no insta metadata churn); touches just the 15 `@aarch64` `.snap` files.
- x86_64 / i686 snapshots are untouched.

Independent of any feature work; unblocks `build-aarch64` for all open PRs.
