### PR TITLE
Extent-aware deduplication of followed references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### New
 
+- `Rc<T>` and `Arc<T>` now support unsized pointees (`Rc<str>`,
+  `Arc<[T]>`, ...). The control-block allocation is measured by extending
+  the header layout with the layout of the pointed-to value, exactly like
+  the standard library computes it.
+
 - Added `MemSize`/`MemDbg` implementations, behind the `aliasable` feature,
   for the `aliasable` crate: `AliasableBox` mirrors `Box`, `AliasableVec`
   mirrors `Vec`, `AliasableString` mirrors `String`, and `AliasableMut`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@
 
 ### Fixed
 
+- Under `SizeFlags::FOLLOW_REFS`, lock guards (`MutexGuard`,
+  `RwLockReadGuard`, `RwLockWriteGuard`) now record their target in the
+  same deduplication map as plain references, so several guards of the
+  same lock (or a guard and a reference to the same value) count the
+  target once. The guarded value is now counted in full, like `&T`,
+  rather than by its heap extras only.
+
 - Under `SizeFlags::FOLLOW_REFS`, two references sharing an address but
   spanning regions of different sizes (e.g., a reference to a struct and a
   reference to its first field, or overlapping slices) were deduplicated by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,22 @@
   reported sizes and generated code are unchanged. A `mem_size` benchmark guards
   the flat and per-element size paths.
 
+### Changed
+
+- The deduplication map passed to `MemSize::mem_size_rec` now maps pointer
+  addresses to a `RefRecord` containing the stack extent of the referent
+  and its computed size, instead of the size alone. Manual implementations
+  that mention the map type must be updated; implementations that ignore
+  the parameter are unaffected.
+
 ### Fixed
+
+- Under `SizeFlags::FOLLOW_REFS`, two references sharing an address but
+  spanning regions of different sizes (e.g., a reference to a struct and a
+  reference to its first field, or overlapping slices) were deduplicated by
+  address alone, making the result dependent on encounter order and
+  undercounting when the smaller referent was met first. The region is now
+  counted once by its largest extent, regardless of order.
 
 - Following a reference, `Rc`, or `Arc` cycle under `SizeFlags::FOLLOW_REFS` or
   `SizeFlags::FOLLOW_RCS` no longer recurses forever. The pointer address is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@
 
 ### Fixed
 
+- Following a reference, `Rc`, or `Arc` cycle under `SizeFlags::FOLLOW_REFS` or
+  `SizeFlags::FOLLOW_RCS` no longer recurses forever. The pointer address is now
+  recorded before recursing, so a cycle is cut on re-entry while the allocation
+  is still counted once.
+
 - `mmap_rs::Mmap` and `mmap_rs::MmapMut` now always count their mapped region as
   part of `mem_size`. Previously the bytes were only counted under
   `SizeFlags::FOLLOW_REFS`, which is inconsistent with ownership semantics (the

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ In both cases, references will be accounted for (when computing size) and
 followed (when displaying the layout), only at their first instance. Subsequent
 instances will just display an arrow followed by a pointer.
 
+Because each address is recorded the first time it is seen, following a value
+that contains a cycle (for example an `Rc` or reference that, directly or
+indirectly, points back to itself) terminates rather than recursing forever:
+the allocation behind the cycle is still counted exactly once.
+
 ## Padding
 
 The trait [`MemDbg`] is useful to display the layout of a value and understand

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ impl MemSize for IntOrFloatI {
     fn mem_size_rec(
         &self,
         _flags: SizeFlags,
-        _refs: &mut HashMap<usize, usize>,
+        _refs: &mut HashMap<usize, RefRecord>,
     ) -> usize {
         core::mem::size_of::<Self>()
     }
@@ -413,7 +413,7 @@ impl MemSize for IntOrFloatF {
     fn mem_size_rec(
         &self,
         _flags: SizeFlags,
-        _refs: &mut HashMap<usize, usize>,
+        _refs: &mut HashMap<usize, RefRecord>,
     ) -> usize {
         core::mem::size_of::<Self>()
     }

--- a/mem_dbg-derive/src/lib.rs
+++ b/mem_dbg-derive/src/lib.rs
@@ -130,7 +130,7 @@ pub fn mem_dbg_mem_size(input: TokenStream) -> TokenStream {
 
                 #[automatically_derived]
                 impl #impl_generics ::mem_dbg::MemSize for #input_ident #ty_generics #where_clause {
-                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::HashMap<usize, usize>) -> usize {
+                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::HashMap<usize, ::mem_dbg::RefRecord>) -> usize {
                         #const_assert
                         let mut bytes = ::core::mem::size_of::<Self>();
                         #(bytes += <#fields_ty as ::mem_dbg::MemSize>::mem_size_rec(&self.#fields_ident, _memsize_flags, _memsize_refs) - ::core::mem::size_of::<#fields_ty>();)*
@@ -236,7 +236,7 @@ pub fn mem_dbg_mem_size(input: TokenStream) -> TokenStream {
 
                 #[automatically_derived]
                 impl #impl_generics ::mem_dbg::MemSize for #input_ident #ty_generics #where_clause {
-                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::HashMap<usize, usize>) -> usize {
+                    fn mem_size_rec(&self, _memsize_flags: ::mem_dbg::SizeFlags, _memsize_refs: &mut ::mem_dbg::HashMap<usize, ::mem_dbg::RefRecord>) -> usize {
                         #const_assert
                         match self {
                             #(

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -786,7 +786,7 @@ impl crate::MemSize for MutablyBorrowed {
     fn mem_size_rec(
         &self,
         _flags: crate::SizeFlags,
-        _refs: &mut crate::HashMap<usize, usize>,
+        _refs: &mut crate::HashMap<usize, crate::RefRecord>,
     ) -> usize {
         0
     }

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -414,8 +414,8 @@ impl<P: MemDbgImpl> MemDbgImpl for core::pin::Pin<P> {
 /// This implementation displays the referenced data with deduplication
 /// when FOLLOW_RCS is set.
 #[cfg(feature = "std")]
-impl<T: MemDbgImpl> MemDbgImpl for std::rc::Rc<T> {
-    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::rc::Rc::as_ptr(s) as usize);
+impl<T: ?Sized + MemDbgImpl> MemDbgImpl for std::rc::Rc<T> {
+    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::rc::Rc::as_ptr(s) as *const () as usize);
 }
 
 // Weak pointers are displayed as handles only.
@@ -428,8 +428,9 @@ impl<T: ?Sized> MemDbgImpl for std::rc::Weak<T> {}
 /// This implementation displays the referenced data with deduplication
 /// when FOLLOW_RCS is set.
 #[cfg(feature = "std")]
-impl<T: MemDbgImpl> MemDbgImpl for std::sync::Arc<T> {
-    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::sync::Arc::as_ptr(s) as usize);
+impl<T: ?Sized + MemDbgImpl> MemDbgImpl for std::sync::Arc<T> {
+    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::sync::Arc::as_ptr(s) as *const ()
+        as usize);
 }
 
 // Weak pointers are displayed as handles only.

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -13,7 +13,7 @@ use core::sync::atomic::*;
 #[cfg(feature = "std")]
 use core::ops::Deref;
 
-use crate::{Boolean, False, FlatType, HashMap, MemSize, SizeFlags, True};
+use crate::{Boolean, False, FlatType, HashMap, MemSize, RefRecord, SizeFlags, True};
 
 #[cfg(not(feature = "std"))]
 use alloc::borrow::{Cow, ToOwned};
@@ -36,7 +36,7 @@ macro_rules! impl_size_of {
 
         impl MemSize for $ty {
             #[inline(always)]
-            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
                 core::mem::size_of::<Self>()
             }
         }
@@ -65,7 +65,7 @@ impl FlatType for str {
 }
 
 impl MemSize for str {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         self.len()
     }
 }
@@ -75,7 +75,7 @@ impl FlatType for String {
 }
 
 impl MemSize for String {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::CAPACITY) {
                 self.capacity()
@@ -92,7 +92,7 @@ impl<T: ?Sized> FlatType for PhantomData<T> {
 }
 
 impl<T: ?Sized> MemSize for PhantomData<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         0
     }
 }
@@ -102,17 +102,53 @@ impl<T: ?Sized> MemSize for PhantomData<T> {
 /// Records the recursive size behind a reference once when `FOLLOW_REFS` is
 /// set, keyed by pointer address. A zero-size sentinel is inserted before
 /// recursing so that reference cycles terminate instead of recursing forever.
+///
+/// Two references can share an address while spanning regions of different
+/// sizes (e.g., a reference to a struct and a reference to its first
+/// field). The recorded [`RefRecord::extent`] disambiguates: an address is
+/// skipped only if the recorded extent already covers the new referent,
+/// while a strictly larger referent is recursed again and replaces the
+/// record, as it strictly contains the smaller one.
 #[inline(always)]
 fn record_followed_pointer_size<T: ?Sized + MemSize>(
     value: &T,
     ptr: usize,
     flags: SizeFlags,
-    refs: &mut HashMap<usize, usize>,
+    refs: &mut HashMap<usize, RefRecord>,
 ) {
-    if flags.contains(SizeFlags::FOLLOW_REFS) && !refs.contains_key(&ptr) {
-        refs.insert(ptr, 0);
-        let inner_size = <T as MemSize>::mem_size_rec(value, flags, refs);
-        refs.insert(ptr, inner_size);
+    if flags.contains(SizeFlags::FOLLOW_REFS) {
+        let extent = core::mem::size_of_val(value);
+        record_followed_size(ptr, extent, refs, |refs| {
+            <T as MemSize>::mem_size_rec(value, flags, refs)
+        });
+    }
+}
+
+/// Common extent-aware recording logic for followed pointers: skips
+/// referents already covered by a recorded extent at the same address,
+/// inserts a zero-size sentinel to break cycles, and never overwrites a
+/// record left by a larger referent.
+#[inline(always)]
+fn record_followed_size(
+    ptr: usize,
+    extent: usize,
+    refs: &mut HashMap<usize, RefRecord>,
+    compute_size: impl FnOnce(&mut HashMap<usize, RefRecord>) -> usize,
+) {
+    if let Some(record) = refs.get(&ptr) {
+        if record.extent >= extent {
+            return;
+        }
+    }
+    refs.insert(ptr, RefRecord { extent, size: 0 });
+    let size = compute_size(refs);
+    // While recursing, a larger referent at the same address may have
+    // been recorded; do not clobber it.
+    match refs.get(&ptr) {
+        Some(record) if record.extent > extent => {}
+        _ => {
+            refs.insert(ptr, RefRecord { extent, size });
+        }
     }
 }
 
@@ -121,7 +157,7 @@ impl<T: ?Sized + MemSize> FlatType for &'_ T {
 }
 
 impl<T: ?Sized + MemSize> MemSize for &'_ T {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         record_followed_pointer_size(*self, *self as *const T as *const () as usize, flags, refs);
         core::mem::size_of::<Self>()
     }
@@ -132,7 +168,7 @@ impl<T: ?Sized + MemSize> FlatType for &'_ mut T {
 }
 
 impl<T: ?Sized + MemSize> MemSize for &'_ mut T {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         <&'_ T as MemSize>::mem_size_rec(&&**self, flags, refs)
     }
 }
@@ -145,7 +181,7 @@ impl<T: ?Sized> FlatType for *const T {
 }
 
 impl<T: ?Sized> MemSize for *const T {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -155,7 +191,7 @@ impl<T: ?Sized> FlatType for *mut T {
 }
 
 impl<T: ?Sized> MemSize for *mut T {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -167,7 +203,7 @@ impl<T: FlatType> FlatType for Option<T> {
 }
 
 impl<T: MemSize> MemSize for Option<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + self.as_ref().map_or(0, |x| {
                 <T as MemSize>::mem_size_rec(x, flags, refs) - core::mem::size_of::<T>()
@@ -182,7 +218,7 @@ impl<T: FlatType, E: FlatType> FlatType for Result<T, E> {
 }
 
 impl<T: MemSize, E: MemSize> MemSize for Result<T, E> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 Ok(t) => <T as MemSize>::mem_size_rec(t, flags, refs) - core::mem::size_of::<T>(),
@@ -198,7 +234,7 @@ impl<B: FlatType, C: FlatType> FlatType for core::ops::ControlFlow<B, C> {
 }
 
 impl<B: MemSize, C: MemSize> MemSize for core::ops::ControlFlow<B, C> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 core::ops::ControlFlow::Break(b) => {
@@ -216,7 +252,7 @@ impl<T: FlatType> FlatType for core::task::Poll<T> {
 }
 
 impl<T: MemSize> MemSize for core::task::Poll<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 core::task::Poll::Ready(t) => {
@@ -232,7 +268,7 @@ impl<T: FlatType> FlatType for core::ops::Bound<T> {
 }
 
 impl<T: MemSize> MemSize for core::ops::Bound<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 core::ops::Bound::Included(t) | core::ops::Bound::Excluded(t) => {
@@ -250,7 +286,7 @@ impl<T: FlatType> FlatType for core::cmp::Reverse<T> {
 // Reverse<T> is repr(transparent) over T, so we forward straight to the inner
 // value, like Cell, UnsafeCell, and Pin.
 impl<T: MemSize> MemSize for core::cmp::Reverse<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         <T as MemSize>::mem_size_rec(&self.0, flags, refs)
     }
 }
@@ -262,7 +298,7 @@ impl<T: ?Sized> FlatType for Box<T> {
 }
 
 impl<T: ?Sized + MemSize> MemSize for Box<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>() + <T as MemSize>::mem_size_rec(self.as_ref(), flags, refs)
     }
 }
@@ -279,7 +315,7 @@ where
     B: ToOwned + MemSize + ?Sized,
     B::Owned: MemSize,
 {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + match self {
                 Cow::Borrowed(borrowed) => {
@@ -301,7 +337,7 @@ impl<P: FlatType> FlatType for core::pin::Pin<P> {
 }
 
 impl<P: MemSize> MemSize for core::pin::Pin<P> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         // SAFETY: `Pin<P>` is `#[repr(transparent)]` over `P`, so `&Pin<P>`
         // and `&P` have identical layout. Taking a shared reference to `P`
         // does not move the pointee.
@@ -323,7 +359,8 @@ struct RcInner<T: ?Sized> {
 
 /// Records the allocation behind an `Rc`/`Arc`-style shared pointer once when
 /// `FOLLOW_RCS` is set, including its control-block header. A zero-size
-/// sentinel is inserted before recursing so that cycles terminate.
+/// sentinel is inserted before recursing so that cycles terminate. Extents
+/// are handled as in [`record_followed_pointer_size`].
 #[cfg(feature = "std")]
 #[inline(always)]
 fn record_followed_shared_size<T: MemSize>(
@@ -331,13 +368,14 @@ fn record_followed_shared_size<T: MemSize>(
     ptr: usize,
     inner_header_size: usize,
     flags: SizeFlags,
-    refs: &mut HashMap<usize, usize>,
+    refs: &mut HashMap<usize, RefRecord>,
 ) {
-    if flags.contains(SizeFlags::FOLLOW_RCS) && !refs.contains_key(&ptr) {
-        refs.insert(ptr, 0);
-        let inner_size = inner_header_size + <T as MemSize>::mem_size_rec(inner, flags, refs)
-            - core::mem::size_of::<T>();
-        refs.insert(ptr, inner_size);
+    if flags.contains(SizeFlags::FOLLOW_RCS) {
+        let extent = core::mem::size_of::<T>();
+        record_followed_size(ptr, extent, refs, |refs| {
+            inner_header_size + <T as MemSize>::mem_size_rec(inner, flags, refs)
+                - core::mem::size_of::<T>()
+        });
     }
 }
 
@@ -363,7 +401,7 @@ impl<T> FlatType for std::rc::Rc<T> {
 /// ```
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::rc::Rc<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         record_followed_shared_size(
             self.as_ref(),
             std::rc::Rc::as_ptr(self) as usize,
@@ -385,7 +423,7 @@ impl<T: ?Sized> FlatType for std::rc::Weak<T> {
 
 #[cfg(feature = "std")]
 impl<T: ?Sized> MemSize for std::rc::Weak<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -424,7 +462,7 @@ struct ArcInner<T: ?Sized> {
 /// ```
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::Arc<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         record_followed_shared_size(
             self.as_ref(),
             std::sync::Arc::as_ptr(self) as usize,
@@ -445,7 +483,7 @@ impl<T: ?Sized> FlatType for std::sync::Weak<T> {
 
 #[cfg(feature = "std")]
 impl<T: ?Sized> MemSize for std::sync::Weak<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -459,7 +497,7 @@ fn element_storage_size<'a, T, I>(
     iter: I,
     len: usize,
     flags: SizeFlags,
-    refs: &mut HashMap<usize, usize>,
+    refs: &mut HashMap<usize, RefRecord>,
 ) -> usize
 where
     T: FlatType + MemSize + 'a,
@@ -481,7 +519,7 @@ fn capacity_backed_storage_size<'a, T, I>(
     len: usize,
     capacity: usize,
     flags: SizeFlags,
-    refs: &mut HashMap<usize, usize>,
+    refs: &mut HashMap<usize, RefRecord>,
 ) -> usize
 where
     T: FlatType + MemSize + 'a,
@@ -510,7 +548,7 @@ where
 fn element_heap_extras<'a, T, I>(
     iter: I,
     flags: SizeFlags,
-    refs: &mut HashMap<usize, usize>,
+    refs: &mut HashMap<usize, RefRecord>,
 ) -> usize
 where
     T: FlatType + MemSize + 'a,
@@ -533,7 +571,7 @@ where
 fn map_heap_extras<'a, K, V, I>(
     iter: I,
     flags: SizeFlags,
-    refs: &mut HashMap<usize, usize>,
+    refs: &mut HashMap<usize, RefRecord>,
 ) -> usize
 where
     K: FlatType + MemSize + 'a,
@@ -570,7 +608,7 @@ impl<T: FlatType> FlatType for [T] {
 }
 
 impl<T: FlatType + MemSize> MemSize for [T] {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         element_storage_size(self.iter(), self.len(), flags, refs)
     }
 }
@@ -582,7 +620,7 @@ impl<T: FlatType, const N: usize> FlatType for [T; N] {
 }
 
 impl<T: FlatType + MemSize, const N: usize> MemSize for [T; N] {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         element_storage_size(self.iter(), N, flags, refs)
     }
 }
@@ -594,7 +632,7 @@ impl<T> FlatType for Vec<T> {
 }
 
 impl<T: FlatType + MemSize> MemSize for Vec<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + capacity_backed_storage_size(self.iter(), self.len(), self.capacity(), flags, refs)
     }
@@ -608,7 +646,7 @@ impl<T> FlatType for BinaryHeap<T> {
 }
 
 impl<T: FlatType + MemSize> MemSize for BinaryHeap<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + capacity_backed_storage_size(self.iter(), self.len(), self.capacity(), flags, refs)
     }
@@ -621,7 +659,7 @@ impl<T> FlatType for VecDeque<T> {
 }
 
 impl<T: FlatType + MemSize> MemSize for VecDeque<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + capacity_backed_storage_size(self.iter(), self.len(), self.capacity(), flags, refs)
     }
@@ -681,7 +719,7 @@ impl<T> FlatType for LinkedList<T> {
 }
 
 impl<T: FlatType + MemSize> MemSize for LinkedList<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + if <<T as FlatType>::Flat as Boolean>::VALUE {
                 self.len() * core::mem::size_of::<LinkedListNode<T>>()
@@ -725,7 +763,7 @@ macro_rules! impl_tuples_muncher {
         }
 
         impl<$ty: MemSize, $($nty: MemSize,)*> MemSize for ($ty, $($nty,)*) {
-            fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+            fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
                 let mut bytes = ::core::mem::size_of::<Self>();
                 bytes += <$ty as MemSize>::mem_size_rec(&self.$idx, flags, refs) - ::core::mem::size_of::<$ty>();
                 $( bytes += <$nty as MemSize>::mem_size_rec(&self.$nidx, flags, refs) - ::core::mem::size_of::<$nty>(); )*
@@ -738,7 +776,7 @@ macro_rules! impl_tuples_muncher {
         }
 
         impl<$ty, $($nty,)* R> MemSize for fn($ty, $($nty,)*) -> R {
-            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+            fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
                 ::core::mem::size_of::<Self>()
             }
         }
@@ -765,7 +803,7 @@ impl<R> FlatType for fn() -> R {
 }
 
 impl<R> MemSize for fn() -> R {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -777,7 +815,7 @@ impl<Idx: FlatType> FlatType for core::ops::Range<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::Range<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + <Idx as MemSize>::mem_size_rec(&self.start, flags, refs)
             + <Idx as MemSize>::mem_size_rec(&self.end, flags, refs)
@@ -790,7 +828,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeFrom<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeFrom<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size_rec(&self.start, flags, refs)
             - core::mem::size_of::<Idx>()
     }
@@ -801,7 +839,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeInclusive<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeInclusive<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + <Idx as MemSize>::mem_size_rec(self.start(), flags, refs)
             + <Idx as MemSize>::mem_size_rec(self.end(), flags, refs)
@@ -814,7 +852,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeTo<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeTo<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size_rec(&self.end, flags, refs)
             - core::mem::size_of::<Idx>()
     }
@@ -825,7 +863,7 @@ impl<Idx: FlatType> FlatType for core::ops::RangeToInclusive<Idx> {
 }
 
 impl<Idx: MemSize> MemSize for core::ops::RangeToInclusive<Idx> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>() + <Idx as MemSize>::mem_size_rec(&self.end, flags, refs)
             - core::mem::size_of::<Idx>()
     }
@@ -852,7 +890,7 @@ impl<T: MemSize> MemSize for core::cell::RefCell<T> {
     /// be observed, so this returns only `size_of::<Self>()` and silently
     /// undercounts any heap reachable through `T`. The `MemDbg`
     /// implementation surfaces this with a `<mutably borrowed>` marker.
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         if let Ok(borrow) = self.try_borrow() {
             core::mem::size_of::<Self>() - core::mem::size_of::<T>()
                 + <T as MemSize>::mem_size_rec(&*borrow, flags, refs)
@@ -874,7 +912,7 @@ impl<T: MemSize> MemSize for core::cell::Cell<T> {
     /// cell while traversal holds the temporary shared reference below.
     /// Violating that contract makes the result invalid and may violate
     /// Rust's aliasing rules.
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         // SAFETY: we temporarily take a shared reference to the inner value;
         // callers must not reentrantly mutate the same cell during traversal.
         let borrow = unsafe { &*self.as_ptr() };
@@ -887,7 +925,7 @@ impl<T: FlatType> FlatType for core::cell::OnceCell<T> {
 }
 
 impl<T: MemSize> MemSize for core::cell::OnceCell<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         let mut size = core::mem::size_of::<Self>();
         if let Some(t) = self.get() {
             size += <T as MemSize>::mem_size_rec(t, flags, refs) - core::mem::size_of::<T>();
@@ -903,7 +941,7 @@ impl<T: FlatType> FlatType for std::sync::OnceLock<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::OnceLock<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         let mut size = core::mem::size_of::<Self>();
         if let Some(t) = self.get() {
             size += <T as MemSize>::mem_size_rec(t, flags, refs) - core::mem::size_of::<T>();
@@ -920,7 +958,7 @@ impl<T: MemSize> MemSize for core::cell::UnsafeCell<T> {
     /// Same reentrancy contract as `Cell<T>`: custom `MemSize` impls must
     /// not mutate this cell through another `UnsafeCell::get()` while
     /// traversal holds the temporary shared reference below.
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         // SAFETY: we temporarily take a shared reference to the inner value;
         // callers must not mutate through another `UnsafeCell::get()` during
         // traversal.
@@ -938,7 +976,7 @@ impl<T: FlatType> FlatType for std::sync::Mutex<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::Mutex<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         // Use unwrap_or_else to handle poisoned mutexes gracefully
         let guard = self.lock().unwrap_or_else(|e| e.into_inner());
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
@@ -953,7 +991,7 @@ impl<T: FlatType> FlatType for std::sync::RwLock<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::RwLock<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         // Use unwrap_or_else to handle poisoned locks gracefully
         let guard = self.read().unwrap_or_else(|e| e.into_inner());
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
@@ -970,7 +1008,7 @@ impl<T: MemSize> MemSize for std::sync::RwLock<T> {
 /// * `flags` - The SizeFlags to use for the computation.
 #[cfg(feature = "std")]
 #[inline(always)]
-fn deref_pointer_size<M>(obj: &M, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize
+fn deref_pointer_size<M>(obj: &M, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize
 where
     M: Deref<Target: MemSize + Sized>,
 {
@@ -990,7 +1028,7 @@ impl<T> FlatType for std::sync::MutexGuard<'_, T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::MutexGuard<'_, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         deref_pointer_size(self, flags, refs)
     }
 }
@@ -1002,7 +1040,7 @@ impl<T> FlatType for std::sync::RwLockReadGuard<'_, T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::RwLockReadGuard<'_, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         deref_pointer_size(self, flags, refs)
     }
 }
@@ -1014,7 +1052,7 @@ impl<T> FlatType for std::sync::RwLockWriteGuard<'_, T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::RwLockWriteGuard<'_, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         deref_pointer_size(self, flags, refs)
     }
 }
@@ -1028,7 +1066,7 @@ impl FlatType for std::path::Path {
 
 #[cfg(feature = "std")]
 impl MemSize for std::path::Path {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         <std::ffi::OsStr as MemSize>::mem_size_rec(self.as_os_str(), flags, refs)
     }
 }
@@ -1040,7 +1078,7 @@ impl FlatType for std::path::PathBuf {
 
 #[cfg(feature = "std")]
 impl MemSize for std::path::PathBuf {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
             + if flags.contains(SizeFlags::CAPACITY) {
                 self.capacity()
@@ -1057,7 +1095,7 @@ impl FlatType for std::ffi::OsStr {
 
 #[cfg(feature = "std")]
 impl MemSize for std::ffi::OsStr {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         self.as_encoded_bytes().len()
     }
 }
@@ -1069,7 +1107,7 @@ impl FlatType for std::ffi::OsString {
 
 #[cfg(feature = "std")]
 impl MemSize for std::ffi::OsString {
-    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         // OsString is like String - it has heap-allocated data
         // We use len() by default, and capacity() with CAPACITY flag
         core::mem::size_of::<Self>()
@@ -1119,7 +1157,7 @@ impl<T> FlatType for std::io::BufReader<T> {
 // types and always report `capacity()`.
 #[cfg(feature = "std")]
 impl<T: MemSize + std::io::Read> MemSize for std::io::BufReader<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + self.capacity()
             + <T as MemSize>::mem_size_rec(self.get_ref(), flags, refs)
@@ -1133,7 +1171,7 @@ impl<T: std::io::Write> FlatType for std::io::BufWriter<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize + std::io::Write> MemSize for std::io::BufWriter<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + self.capacity()
             + <T as MemSize>::mem_size_rec(self.get_ref(), flags, refs)
@@ -1147,7 +1185,7 @@ impl<T> FlatType for std::io::Cursor<T> {
 
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::io::Cursor<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + <T as MemSize>::mem_size_rec(self.get_ref(), flags, refs)
     }
@@ -1182,7 +1220,7 @@ impl FlatType for mmap_rs::Mmap {
 
 #[cfg(feature = "mmap-rs")]
 impl MemSize for mmap_rs::Mmap {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         // `Mmap` owns its mapped region and unmaps it on drop, so its bytes
         // belong to the value's footprint regardless of `FOLLOW_REFS`. There
         // is no notion of unused capacity for an mmap, so `CAPACITY` is a
@@ -1198,7 +1236,7 @@ impl FlatType for mmap_rs::MmapMut {
 
 #[cfg(feature = "mmap-rs")]
 impl MemSize for mmap_rs::MmapMut {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         // See `Mmap` above.
         core::mem::size_of::<Self>() + self.len()
     }
@@ -1262,7 +1300,7 @@ impl<T> FlatType for std::collections::HashSet<T> {
 
 #[cfg(feature = "std")]
 impl<T: FlatType + MemSize> MemSize for std::collections::HashSet<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         let elements_size = element_storage_size(self.iter(), self.len(), flags, refs);
         fix_set_for_capacity(self, elements_size, flags)
     }
@@ -1297,7 +1335,7 @@ impl<K, V> FlatType for std::collections::HashMap<K, V> {
 
 #[cfg(feature = "std")]
 impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSize for std::collections::HashMap<K, V> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         // Inline key/value storage plus, in a single pass over the entries,
         // any per-entry heap (zero when both K and V are flat).
         let inline_size = self.len() * (core::mem::size_of::<K>() + core::mem::size_of::<V>());
@@ -1429,7 +1467,7 @@ impl<T> FlatType for std::collections::BTreeSet<T> {
 
 #[cfg(feature = "std")]
 impl<T: FlatType + MemSize> MemSize for std::collections::BTreeSet<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         let item_heap_size = element_heap_extras(self.iter(), flags, refs);
         core::mem::size_of::<std::collections::BTreeSet<T>>()
             + estimate_btree_size::<T, ()>(self.len(), item_heap_size)
@@ -1443,7 +1481,7 @@ impl<K, V> FlatType for std::collections::BTreeMap<K, V> {
 
 #[cfg(feature = "std")]
 impl<K: FlatType + MemSize, V: FlatType + MemSize> MemSize for std::collections::BTreeMap<K, V> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         let item_heap_size = map_heap_extras(self.iter(), flags, refs);
         core::mem::size_of::<std::collections::BTreeMap<K, V>>()
             + estimate_btree_size::<K, V>(self.len(), item_heap_size)
@@ -1456,7 +1494,7 @@ impl<H> FlatType for core::hash::BuildHasherDefault<H> {
     type Flat = True;
 }
 impl<H> MemSize for core::hash::BuildHasherDefault<H> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         // it's a phantom hash
         debug_assert_eq!(core::mem::size_of::<Self>(), 0);
         0
@@ -1472,7 +1510,7 @@ impl FlatType for std::hash::DefaultHasher {
 // This implementation assumes that DefaultHasher is a fixed-size type
 // that does not allocate memory on the heap.
 impl MemSize for std::hash::DefaultHasher {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -1484,7 +1522,7 @@ impl FlatType for std::collections::hash_map::RandomState {
 
 #[cfg(feature = "std")]
 impl MemSize for std::collections::hash_map::RandomState {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -1498,7 +1536,7 @@ impl<T: ?Sized> FlatType for core::ptr::NonNull<T> {
 }
 
 impl<T: ?Sized> MemSize for core::ptr::NonNull<T> {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of::<Self>()
     }
 }
@@ -1525,7 +1563,7 @@ impl<A: maligned::Alignment, T: MemSize + FlatType> FlatType for maligned::Align
 
 #[cfg(feature = "maligned")]
 impl<A: maligned::Alignment, T: MemSize> MemSize for maligned::Aligned<A, T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         use core::ops::Deref;
         core::mem::size_of::<Self>() - core::mem::size_of::<T>()
             + <T as MemSize>::mem_size_rec(self.deref(), flags, refs)
@@ -1561,7 +1599,7 @@ mod aliasable {
     }
 
     impl<T: ?Sized + MemSize> MemSize for AliasableBox<T> {
-        fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
             core::mem::size_of::<Self>() + <T as MemSize>::mem_size_rec(self.deref(), flags, refs)
         }
     }
@@ -1571,7 +1609,7 @@ mod aliasable {
     }
 
     impl<T: FlatType + MemSize> MemSize for AliasableVec<T> {
-        fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
             core::mem::size_of::<Self>() + <[T] as MemSize>::mem_size_rec(self.deref(), flags, refs)
         }
     }
@@ -1581,7 +1619,7 @@ mod aliasable {
     }
 
     impl MemSize for AliasableString {
-        fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+        fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
             core::mem::size_of::<Self>() + self.deref().len()
         }
     }
@@ -1591,7 +1629,7 @@ mod aliasable {
     }
 
     impl<T: ?Sized + MemSize> MemSize for AliasableMut<'_, T> {
-        fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+        fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
             <&T as MemSize>::mem_size_rec(&self.deref(), flags, refs)
         }
     }
@@ -1609,7 +1647,7 @@ impl<T: FlatType> FlatType for maybe_dangling::MaybeDangling<T> {
 
 #[cfg(feature = "maybe-dangling")]
 impl<T: MemSize> MemSize for maybe_dangling::MaybeDangling<T> {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         use core::ops::Deref;
         <T as MemSize>::mem_size_rec(self.deref(), flags, refs)
     }

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1002,6 +1002,11 @@ impl<T: MemSize> MemSize for std::sync::RwLock<T> {
 /// Helper function to compute the size of a Deref pointer type,
 /// such as `MutexGuard`, `RwLockReadGuard`, `RwLockWriteGuard`.
 ///
+/// Under [`SizeFlags::FOLLOW_REFS`] the guarded value is recorded in the
+/// deduplication map exactly like a plain reference, so several guards of
+/// the same lock (or a guard and a reference to the same value) count the
+/// target once.
+///
 /// # Arguments
 ///
 /// * `obj` - The Deref pointer object.
@@ -1012,13 +1017,9 @@ fn deref_pointer_size<M>(obj: &M, flags: SizeFlags, refs: &mut HashMap<usize, Re
 where
     M: Deref<Target: MemSize + Sized>,
 {
+    let target = obj.deref();
+    record_followed_pointer_size(target, target as *const M::Target as usize, flags, refs);
     core::mem::size_of::<M>()
-        + if flags.contains(SizeFlags::FOLLOW_REFS) {
-            <M::Target as MemSize>::mem_size_rec(obj.deref(), flags, refs)
-                - core::mem::size_of::<M::Target>()
-        } else {
-            0
-        }
 }
 
 #[cfg(feature = "std")]

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -348,7 +348,9 @@ impl<P: MemSize> MemSize for core::pin::Pin<P> {
 
 // Rc: uses map for deduplication when FOLLOW_RCS is set
 
-// Structure used to measure the size of RcInner in std
+// Structure used to measure the layout of std's RcInner header; only
+// instantiated as RcInner<()>, whose layout is extended with the layout of
+// the pointed-to value exactly like std::rc::Rc::allocate_for_layout does.
 #[cfg(feature = "std")]
 #[repr(C, align(2))]
 struct RcInner<T: ?Sized> {
@@ -361,26 +363,38 @@ struct RcInner<T: ?Sized> {
 /// `FOLLOW_RCS` is set, including its control-block header. A zero-size
 /// sentinel is inserted before recursing so that cycles terminate. Extents
 /// are handled as in [`record_followed_pointer_size`].
+///
+/// The allocation size is computed like the standard library computes it:
+/// the control-block header layout is extended with the layout of the
+/// pointed-to value and padded to alignment. This is exact for sized and
+/// unsized pointees alike.
 #[cfg(feature = "std")]
 #[inline(always)]
-fn record_followed_shared_size<T: MemSize>(
+fn record_followed_shared_size<T: ?Sized + MemSize>(
     inner: &T,
     ptr: usize,
-    inner_header_size: usize,
+    header_layout: core::alloc::Layout,
     flags: SizeFlags,
     refs: &mut HashMap<usize, RefRecord>,
 ) {
     if flags.contains(SizeFlags::FOLLOW_RCS) {
-        let extent = core::mem::size_of::<T>();
+        let extent = core::mem::size_of_val(inner);
         record_followed_size(ptr, extent, refs, |refs| {
-            inner_header_size + <T as MemSize>::mem_size_rec(inner, flags, refs)
-                - core::mem::size_of::<T>()
+            let alloc_size = header_layout
+                .extend(core::alloc::Layout::for_value(inner))
+                // Cannot overflow: the allocation exists.
+                .expect("layout overflow")
+                .0
+                .pad_to_align()
+                .size();
+            alloc_size - core::mem::size_of_val(inner)
+                + <T as MemSize>::mem_size_rec(inner, flags, refs)
         });
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> FlatType for std::rc::Rc<T> {
+impl<T: ?Sized> FlatType for std::rc::Rc<T> {
     type Flat = False;
 }
 
@@ -400,12 +414,12 @@ impl<T> FlatType for std::rc::Rc<T> {
 /// }
 /// ```
 #[cfg(feature = "std")]
-impl<T: MemSize> MemSize for std::rc::Rc<T> {
+impl<T: ?Sized + MemSize> MemSize for std::rc::Rc<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         record_followed_shared_size(
             self.as_ref(),
-            std::rc::Rc::as_ptr(self) as usize,
-            core::mem::size_of::<RcInner<T>>(),
+            std::rc::Rc::as_ptr(self) as *const () as usize,
+            core::alloc::Layout::new::<RcInner<()>>(),
             flags,
             refs,
         );
@@ -431,11 +445,13 @@ impl<T: ?Sized> MemSize for std::rc::Weak<T> {
 // Arc: uses map for deduplication when FOLLOW_RCS is set
 
 #[cfg(feature = "std")]
-impl<T> FlatType for std::sync::Arc<T> {
+impl<T: ?Sized> FlatType for std::sync::Arc<T> {
     type Flat = False;
 }
 
-// Structure used to measure the size of ArcInner in std
+// Structure used to measure the layout of std's ArcInner header; only
+// instantiated as ArcInner<()>, whose layout is extended with the layout of
+// the pointed-to value exactly like std::sync::Arc::allocate_for_layout does.
 #[cfg(feature = "std")]
 #[repr(C, align(2))]
 struct ArcInner<T: ?Sized> {
@@ -461,12 +477,12 @@ struct ArcInner<T: ?Sized> {
 /// }
 /// ```
 #[cfg(feature = "std")]
-impl<T: MemSize> MemSize for std::sync::Arc<T> {
+impl<T: ?Sized + MemSize> MemSize for std::sync::Arc<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         record_followed_shared_size(
             self.as_ref(),
-            std::sync::Arc::as_ptr(self) as usize,
-            core::mem::size_of::<ArcInner<T>>(),
+            std::sync::Arc::as_ptr(self) as *const () as usize,
+            core::alloc::Layout::new::<ArcInner<()>>(),
             flags,
             refs,
         );

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -99,19 +99,30 @@ impl<T: ?Sized> MemSize for PhantomData<T> {
 
 // References: we recurse only if FOLLOW_REFS is set, and use the map for deduplication
 
+/// Records the recursive size behind a reference once when `FOLLOW_REFS` is
+/// set, keyed by pointer address. A zero-size sentinel is inserted before
+/// recursing so that reference cycles terminate instead of recursing forever.
+#[inline(always)]
+fn record_followed_pointer_size<T: ?Sized + MemSize>(
+    value: &T,
+    ptr: usize,
+    flags: SizeFlags,
+    refs: &mut HashMap<usize, usize>,
+) {
+    if flags.contains(SizeFlags::FOLLOW_REFS) && !refs.contains_key(&ptr) {
+        refs.insert(ptr, 0);
+        let inner_size = <T as MemSize>::mem_size_rec(value, flags, refs);
+        refs.insert(ptr, inner_size);
+    }
+}
+
 impl<T: ?Sized + MemSize> FlatType for &'_ T {
     type Flat = False;
 }
 
 impl<T: ?Sized + MemSize> MemSize for &'_ T {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
-        if flags.contains(SizeFlags::FOLLOW_REFS) {
-            let ptr = *self as *const T as *const () as usize;
-            if !refs.contains_key(&ptr) {
-                let inner_size = <T as MemSize>::mem_size_rec(*self, flags, refs);
-                refs.insert(ptr, inner_size);
-            }
-        }
+        record_followed_pointer_size(*self, *self as *const T as *const () as usize, flags, refs);
         core::mem::size_of::<Self>()
     }
 }
@@ -310,6 +321,26 @@ struct RcInner<T: ?Sized> {
     _data: T,
 }
 
+/// Records the allocation behind an `Rc`/`Arc`-style shared pointer once when
+/// `FOLLOW_RCS` is set, including its control-block header. A zero-size
+/// sentinel is inserted before recursing so that cycles terminate.
+#[cfg(feature = "std")]
+#[inline(always)]
+fn record_followed_shared_size<T: MemSize>(
+    inner: &T,
+    ptr: usize,
+    inner_header_size: usize,
+    flags: SizeFlags,
+    refs: &mut HashMap<usize, usize>,
+) {
+    if flags.contains(SizeFlags::FOLLOW_RCS) && !refs.contains_key(&ptr) {
+        refs.insert(ptr, 0);
+        let inner_size = inner_header_size + <T as MemSize>::mem_size_rec(inner, flags, refs)
+            - core::mem::size_of::<T>();
+        refs.insert(ptr, inner_size);
+    }
+}
+
 #[cfg(feature = "std")]
 impl<T> FlatType for std::rc::Rc<T> {
     type Flat = False;
@@ -333,16 +364,13 @@ impl<T> FlatType for std::rc::Rc<T> {
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::rc::Rc<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
-        if flags.contains(SizeFlags::FOLLOW_RCS) {
-            let ptr = std::rc::Rc::as_ptr(self) as usize;
-            if !refs.contains_key(&ptr) {
-                // Size of RcInner (header) + inner value's recursive size
-                let inner_size = core::mem::size_of::<RcInner<T>>()
-                    + <T as MemSize>::mem_size_rec(self.as_ref(), flags, refs)
-                    - core::mem::size_of::<T>();
-                refs.insert(ptr, inner_size);
-            }
-        }
+        record_followed_shared_size(
+            self.as_ref(),
+            std::rc::Rc::as_ptr(self) as usize,
+            core::mem::size_of::<RcInner<T>>(),
+            flags,
+            refs,
+        );
         core::mem::size_of::<Self>()
     }
 }
@@ -397,16 +425,13 @@ struct ArcInner<T: ?Sized> {
 #[cfg(feature = "std")]
 impl<T: MemSize> MemSize for std::sync::Arc<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize {
-        if flags.contains(SizeFlags::FOLLOW_RCS) {
-            let ptr = std::sync::Arc::as_ptr(self) as usize;
-            if !refs.contains_key(&ptr) {
-                // Size of ArcInner (header) + inner value's recursive size
-                let inner_size = core::mem::size_of::<ArcInner<T>>()
-                    + <T as MemSize>::mem_size_rec(self.as_ref(), flags, refs)
-                    - core::mem::size_of::<T>();
-                refs.insert(ptr, inner_size);
-            }
-        }
+        record_followed_shared_size(
+            self.as_ref(),
+            std::sync::Arc::as_ptr(self) as usize,
+            core::mem::size_of::<ArcInner<T>>(),
+            flags,
+            refs,
+        );
         core::mem::size_of::<Self>()
     }
 }

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -21,6 +21,27 @@ pub use hashbrown::HashMap;
 #[doc(hidden)]
 pub use hashbrown::HashSet;
 
+/// Record of a followed reference in the deduplication map passed to
+/// [`MemSize::mem_size_rec`].
+///
+/// The map is keyed by the referent's address. Since two references can
+/// share an address while spanning different regions (e.g., a reference
+/// to a struct and a reference to its first field), each record stores
+/// the stack extent of the referent: a re-encountered address is skipped
+/// only if the recorded extent already covers the new referent, and a
+/// larger referent at the same address replaces the record, as it
+/// strictly contains the smaller one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RefRecord {
+    /// The stack extent in bytes of the referent, as returned by
+    /// [`core::mem::size_of_val`].
+    pub extent: usize,
+    /// The recursively computed size of the referent; zero while the
+    /// recursive computation is still in progress (this sentinel breaks
+    /// reference cycles).
+    pub size: usize,
+}
+
 #[cfg(feature = "derive")]
 pub use mem_dbg_derive::{MemDbg, MemSize};
 
@@ -197,21 +218,25 @@ pub trait MemSize {
     fn mem_size(&self, flags: SizeFlags) -> usize {
         let mut refs = HashMap::new();
         let base = self.mem_size_rec(flags, &mut refs);
-        base + refs.into_values().sum::<usize>()
+        base + refs.into_values().map(|record| record.size).sum::<usize>()
     }
 
     /// Recursive implementation that tracks visited references for deduplication.
     ///
     /// The parameter `refs` is a map from pointer addresses (coming from
-    /// references) to their computed size that is used to count the space
+    /// references) to a [`RefRecord`] containing the stack extent of the
+    /// referent and its computed size. It is used to count the space
     /// occupied by references only once in case any of the flags
-    /// [`SizeFlags::FOLLOW_REFS`] or [`SizeFlags::FOLLOW_RCS`] is set.
+    /// [`SizeFlags::FOLLOW_REFS`] or [`SizeFlags::FOLLOW_RCS`] is set;
+    /// the extent disambiguates references that share an address but span
+    /// regions of different sizes (e.g., a reference to a struct and a
+    /// reference to its first field).
     ///
     /// In case of custom (non-derive) implementations: types that do not
     /// contain references can simply ignore the `refs` parameter; otherwise,
     /// please have a look at the [implementation for
     /// references](#impl-MemSize-for-%26T).
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, usize>) -> usize;
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize;
 }
 
 bitflags::bitflags! {

--- a/mem_dbg/src/lib.rs
+++ b/mem_dbg/src/lib.rs
@@ -146,7 +146,9 @@ bitflags::bitflags! {
         /// computes only the size of the reference itself. Note that the size
         /// of every reference will be added once (i.e., if you have two
         /// identical references to the same memory region, the size of that
-        /// region will be added only once).
+        /// region will be added only once). Reference cycles are handled by
+        /// this same once-per-address accounting, so following a cyclic value
+        /// terminates instead of recursing forever.
         const FOLLOW_REFS = 1 << 0;
         /// Return capacity instead of size.
         ///
@@ -167,7 +169,9 @@ bitflags::bitflags! {
         /// and computes only the size of the reference itself. Note that the
         /// size of every counted reference will be added once (i.e., if you
         /// have two identical counted references to the same memory region,
-        /// the size of that region will be added only once).
+        /// the size of that region will be added only once). Counted-reference
+        /// cycles are handled by this same once-per-address accounting, so
+        /// following a cyclic value terminates instead of recursing forever.
         const FOLLOW_RCS = 1 << 2;
     }
 }

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-darwin.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -121,21 +121,21 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.42% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.41% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    12 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    26 B   0.06% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    32 B   0.07% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.68% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
  3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
@@ -143,7 +143,7 @@ expression: output
  1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.15% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.06% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.05% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 6_716 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_406 B  10.12% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.03% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-darwin.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-darwin.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -96,29 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -96,29 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -96,21 +96,21 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.42% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.41% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    12 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    26 B   0.06% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    32 B   0.07% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.68% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
  3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
@@ -118,7 +118,7 @@ expression: depth_output
  1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.15% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -96,29 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.06% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.05% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 6_716 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_406 B  10.12% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.03% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-darwin.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -121,21 +121,21 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.42% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.41% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    12 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    26 B   0.06% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    32 B   0.07% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.68% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
  3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
@@ -143,7 +143,7 @@ expression: depth_output
  1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.15% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.06% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.05% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 6_716 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_406 B  10.12% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.03% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/test_followed_cycle_recursion.rs
+++ b/mem_dbg/tests/test_followed_cycle_recursion.rs
@@ -1,0 +1,263 @@
+#![cfg(feature = "std")]
+
+//! Followed-cycle recursion is a runtime concern: `Rc`, `Arc`, and references
+//! may form cycles once follow flags are enabled. These tests make sure visited
+//! pointer tracking stops `MemSize` and `MemDbg` from revisiting the cycle.
+
+use mem_dbg::*;
+
+const MAX_CYCLE_VISITS: usize = 8;
+
+struct CountingRcCycle {
+    size_visits: std::rc::Rc<std::cell::Cell<usize>>,
+    dbg_visits: std::rc::Rc<std::cell::Cell<usize>>,
+    next: std::cell::OnceCell<std::rc::Rc<CountingRcCycle>>,
+}
+
+impl FlatType for CountingRcCycle {
+    type Flat = False;
+}
+
+impl MemSize for CountingRcCycle {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut mem_dbg::HashMap<usize, usize>) -> usize {
+        let visits = self.size_visits.get() + 1;
+        self.size_visits.set(visits);
+        assert!(visits <= MAX_CYCLE_VISITS);
+
+        core::mem::size_of::<Self>()
+            + self.next.get().map_or(0, |next| {
+                <std::rc::Rc<CountingRcCycle> as MemSize>::mem_size_rec(next, flags, refs)
+                    - core::mem::size_of::<std::rc::Rc<CountingRcCycle>>()
+            })
+    }
+}
+
+impl MemDbgImpl for CountingRcCycle {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        _is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut mem_dbg::HashSet<usize>,
+    ) -> core::fmt::Result {
+        let visits = self.dbg_visits.get() + 1;
+        self.dbg_visits.set(visits);
+        assert!(visits <= MAX_CYCLE_VISITS);
+
+        if let Some(next) = self.next.get() {
+            <std::rc::Rc<CountingRcCycle> as MemDbgImpl>::_mem_dbg_depth_on(
+                next,
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("next"),
+                true,
+                core::mem::size_of::<std::rc::Rc<CountingRcCycle>>(),
+                flags,
+                dbg_refs,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+struct CountingArcCycle {
+    size_visits: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    dbg_visits: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    next: std::sync::OnceLock<std::sync::Arc<CountingArcCycle>>,
+}
+
+impl FlatType for CountingArcCycle {
+    type Flat = False;
+}
+
+impl MemSize for CountingArcCycle {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut mem_dbg::HashMap<usize, usize>) -> usize {
+        let visits = self
+            .size_visits
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        assert!(visits <= MAX_CYCLE_VISITS);
+
+        core::mem::size_of::<Self>()
+            + self.next.get().map_or(0, |next| {
+                <std::sync::Arc<CountingArcCycle> as MemSize>::mem_size_rec(next, flags, refs)
+                    - core::mem::size_of::<std::sync::Arc<CountingArcCycle>>()
+            })
+    }
+}
+
+impl MemDbgImpl for CountingArcCycle {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        _is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut mem_dbg::HashSet<usize>,
+    ) -> core::fmt::Result {
+        let visits = self
+            .dbg_visits
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        assert!(visits <= MAX_CYCLE_VISITS);
+
+        if let Some(next) = self.next.get() {
+            <std::sync::Arc<CountingArcCycle> as MemDbgImpl>::_mem_dbg_depth_on(
+                next,
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("next"),
+                true,
+                core::mem::size_of::<std::sync::Arc<CountingArcCycle>>(),
+                flags,
+                dbg_refs,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+struct CountingRefCycle {
+    size_visits: std::cell::Cell<usize>,
+    dbg_visits: std::cell::Cell<usize>,
+    next: std::cell::OnceCell<&'static CountingRefCycle>,
+}
+
+impl FlatType for CountingRefCycle {
+    type Flat = False;
+}
+
+impl MemSize for CountingRefCycle {
+    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut mem_dbg::HashMap<usize, usize>) -> usize {
+        let visits = self.size_visits.get() + 1;
+        self.size_visits.set(visits);
+        assert!(visits <= MAX_CYCLE_VISITS);
+
+        core::mem::size_of::<Self>()
+            + self.next.get().map_or(0, |next| {
+                <&CountingRefCycle as MemSize>::mem_size_rec(next, flags, refs)
+                    - core::mem::size_of::<&CountingRefCycle>()
+            })
+    }
+}
+
+impl MemDbgImpl for CountingRefCycle {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        _is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut mem_dbg::HashSet<usize>,
+    ) -> core::fmt::Result {
+        let visits = self.dbg_visits.get() + 1;
+        self.dbg_visits.set(visits);
+        assert!(visits <= MAX_CYCLE_VISITS);
+
+        if let Some(next) = self.next.get() {
+            <&CountingRefCycle as MemDbgImpl>::_mem_dbg_depth_on(
+                next,
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("next"),
+                true,
+                core::mem::size_of::<&CountingRefCycle>(),
+                flags,
+                dbg_refs,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+// These tests intentionally build ownership cycles (a strong `Rc`/`Arc` cycle,
+// and a `Box::leak`ed `&'static` self-reference) to exercise cycle handling, so
+// they leak by construction. Miri's leak checker correctly objects, and the
+// logic is plain safe Rust covered by the other targets, so skip them on Miri.
+#[cfg_attr(miri, ignore = "intentional ownership cycle leaks")]
+#[test]
+fn followed_rc_cycle_should_not_recurse_forever() {
+    let size_visits = std::rc::Rc::new(std::cell::Cell::new(0));
+    let dbg_visits = std::rc::Rc::new(std::cell::Cell::new(0));
+    let root = std::rc::Rc::new(CountingRcCycle {
+        size_visits: size_visits.clone(),
+        dbg_visits: dbg_visits.clone(),
+        next: std::cell::OnceCell::new(),
+    });
+    assert!(root.next.set(root.clone()).is_ok());
+
+    let size = root.mem_size(SizeFlags::FOLLOW_RCS);
+    assert!(size >= core::mem::size_of::<std::rc::Rc<CountingRcCycle>>());
+    assert_eq!(size_visits.get(), 1);
+
+    let mut output = String::new();
+    root.mem_dbg_depth_on(&mut output, 2, DbgFlags::default() | DbgFlags::FOLLOW_RCS)
+        .unwrap();
+    assert!(output.contains("CountingRcCycle"));
+    assert!(output.contains("→ 0x"));
+    assert_eq!(dbg_visits.get(), 1);
+}
+
+#[cfg_attr(miri, ignore = "intentional ownership cycle leaks")]
+#[test]
+fn followed_arc_cycle_should_not_recurse_forever() {
+    let size_visits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let dbg_visits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let root = std::sync::Arc::new(CountingArcCycle {
+        size_visits: size_visits.clone(),
+        dbg_visits: dbg_visits.clone(),
+        next: std::sync::OnceLock::new(),
+    });
+    assert!(root.next.set(root.clone()).is_ok());
+
+    let size = root.mem_size(SizeFlags::FOLLOW_RCS);
+    assert!(size >= core::mem::size_of::<std::sync::Arc<CountingArcCycle>>());
+    assert_eq!(size_visits.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+    let mut output = String::new();
+    root.mem_dbg_depth_on(&mut output, 2, DbgFlags::default() | DbgFlags::FOLLOW_RCS)
+        .unwrap();
+    assert!(output.contains("CountingArcCycle"));
+    assert!(output.contains("→ 0x"));
+    assert_eq!(dbg_visits.load(std::sync::atomic::Ordering::Relaxed), 1);
+}
+
+#[cfg_attr(miri, ignore = "intentional ownership cycle leaks")]
+#[test]
+fn followed_reference_cycle_should_not_recurse_forever() {
+    let node: &'static CountingRefCycle = Box::leak(Box::new(CountingRefCycle {
+        size_visits: std::cell::Cell::new(0),
+        dbg_visits: std::cell::Cell::new(0),
+        next: std::cell::OnceCell::new(),
+    }));
+    assert!(node.next.set(node).is_ok());
+
+    let size = <&CountingRefCycle as MemSize>::mem_size(&node, SizeFlags::FOLLOW_REFS);
+    assert!(size >= core::mem::size_of::<&CountingRefCycle>());
+    assert_eq!(node.size_visits.get(), 1);
+
+    let mut output = String::new();
+    <&CountingRefCycle as MemDbg>::mem_dbg_depth_on(
+        &node,
+        &mut output,
+        2,
+        DbgFlags::default() | DbgFlags::FOLLOW_REFS,
+    )
+    .unwrap();
+    assert!(output.contains("CountingRefCycle"));
+    assert!(output.contains("→ 0x"));
+    assert_eq!(node.dbg_visits.get(), 1);
+}

--- a/mem_dbg/tests/test_followed_cycle_recursion.rs
+++ b/mem_dbg/tests/test_followed_cycle_recursion.rs
@@ -19,7 +19,11 @@ impl FlatType for CountingRcCycle {
 }
 
 impl MemSize for CountingRcCycle {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut mem_dbg::HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(
+        &self,
+        flags: SizeFlags,
+        refs: &mut mem_dbg::HashMap<usize, RefRecord>,
+    ) -> usize {
         let visits = self.size_visits.get() + 1;
         self.size_visits.set(visits);
         assert!(visits <= MAX_CYCLE_VISITS);
@@ -76,7 +80,11 @@ impl FlatType for CountingArcCycle {
 }
 
 impl MemSize for CountingArcCycle {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut mem_dbg::HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(
+        &self,
+        flags: SizeFlags,
+        refs: &mut mem_dbg::HashMap<usize, RefRecord>,
+    ) -> usize {
         let visits = self
             .size_visits
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -137,7 +145,11 @@ impl FlatType for CountingRefCycle {
 }
 
 impl MemSize for CountingRefCycle {
-    fn mem_size_rec(&self, flags: SizeFlags, refs: &mut mem_dbg::HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(
+        &self,
+        flags: SizeFlags,
+        refs: &mut mem_dbg::HashMap<usize, RefRecord>,
+    ) -> usize {
         let visits = self.size_visits.get() + 1;
         self.size_visits.set(visits);
         assert!(visits <= MAX_CYCLE_VISITS);

--- a/mem_dbg/tests/test_guard_ref_dedup.rs
+++ b/mem_dbg/tests/test_guard_ref_dedup.rs
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests that lock guards deduplicate their target through the same map as
+//! plain references under `SizeFlags::FOLLOW_REFS`.
+
+#![cfg(feature = "std")]
+
+use anyhow::Result;
+use core::mem::size_of;
+use mem_dbg::{MemSize, SizeFlags};
+use std::sync::{RwLock, RwLockReadGuard};
+
+#[test]
+fn test_two_read_guards_count_target_once() -> Result<()> {
+    let lock = RwLock::new(vec![0_u8; 100]);
+    let g1 = lock.read().unwrap();
+    let g2 = lock.read().unwrap();
+
+    let guards = (&g1, &g2);
+    let size = guards.mem_size(SizeFlags::FOLLOW_REFS);
+
+    // Two references, two guards, and the guarded vector counted once.
+    let expected = 2 * size_of::<&RwLockReadGuard<'_, Vec<u8>>>()
+        + 2 * size_of::<RwLockReadGuard<'_, Vec<u8>>>()
+        + size_of::<Vec<u8>>()
+        + 100;
+    assert_eq!(size, expected);
+    Ok(())
+}
+
+#[test]
+fn test_guard_follows_target_like_a_reference() -> Result<()> {
+    let lock = RwLock::new(vec![0_u8; 100]);
+    let guard = lock.read().unwrap();
+
+    // Without FOLLOW_REFS the guard is a handle only.
+    assert_eq!(
+        guard.mem_size(SizeFlags::default()),
+        size_of::<RwLockReadGuard<'_, Vec<u8>>>()
+    );
+
+    // With FOLLOW_REFS the guarded value is counted in full, like `&T`.
+    assert_eq!(
+        guard.mem_size(SizeFlags::FOLLOW_REFS),
+        size_of::<RwLockReadGuard<'_, Vec<u8>>>() + size_of::<Vec<u8>>() + 100
+    );
+    Ok(())
+}

--- a/mem_dbg/tests/test_linked_list.rs
+++ b/mem_dbg/tests/test_linked_list.rs
@@ -70,7 +70,7 @@ fn test_linked_list_aligned_element_node_size() {
         fn mem_size_rec(
             &self,
             _flags: SizeFlags,
-            _refs: &mut mem_dbg::HashMap<usize, usize>,
+            _refs: &mut mem_dbg::HashMap<usize, RefRecord>,
         ) -> usize {
             core::mem::size_of::<Self>()
         }
@@ -103,7 +103,7 @@ fn test_linked_list_with_aligned_heap_elements() {
         fn mem_size_rec(
             &self,
             flags: SizeFlags,
-            refs: &mut mem_dbg::HashMap<usize, usize>,
+            refs: &mut mem_dbg::HashMap<usize, RefRecord>,
         ) -> usize {
             core::mem::size_of::<Self>()
                 + (<Vec<u8> as MemSize>::mem_size_rec(&self.data, flags, refs)

--- a/mem_dbg/tests/test_overlapping_refs.rs
+++ b/mem_dbg/tests/test_overlapping_refs.rs
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests for extent-aware deduplication of followed references: two
+//! references sharing an address but spanning regions of different sizes
+//! must be counted by the largest extent, regardless of encounter order.
+
+use anyhow::Result;
+use core::mem::size_of;
+use mem_dbg::{MemSize, SizeFlags};
+
+#[test]
+fn test_struct_and_first_field_order_independent() -> Result<()> {
+    let pair: (u64, u64) = (1, 2);
+    let whole: &(u64, u64) = &pair;
+    let first: &u64 = &pair.0;
+
+    // Two references plus the pair, counted once by its full extent.
+    let expected = 2 * size_of::<&u64>() + size_of::<(u64, u64)>();
+    assert_eq!((whole, first).mem_size(SizeFlags::FOLLOW_REFS), expected);
+    assert_eq!((first, whole).mem_size(SizeFlags::FOLLOW_REFS), expected);
+    Ok(())
+}
+
+#[test]
+fn test_overlapping_slices_order_independent() -> Result<()> {
+    let v = [1_u8, 2, 3, 4];
+    let big: &[u8] = &v[..];
+    let small: &[u8] = &v[..2];
+
+    // Two fat references plus the slice, counted once by its full extent.
+    let expected = 2 * size_of::<&[u8]>() + size_of::<[u8; 4]>();
+    assert_eq!((big, small).mem_size(SizeFlags::FOLLOW_REFS), expected);
+    assert_eq!((small, big).mem_size(SizeFlags::FOLLOW_REFS), expected);
+    Ok(())
+}
+
+#[test]
+fn test_equal_extents_still_deduplicated() -> Result<()> {
+    let x = 42_u64;
+    let r1 = &x;
+    let r2 = &x;
+
+    let expected = 2 * size_of::<&u64>() + size_of::<u64>();
+    assert_eq!((r1, r2).mem_size(SizeFlags::FOLLOW_REFS), expected);
+    Ok(())
+}

--- a/mem_dbg/tests/test_padded_size_saturation.rs
+++ b/mem_dbg/tests/test_padded_size_saturation.rs
@@ -7,7 +7,7 @@ impl FlatType for TooSmallPadding {
 }
 
 impl MemSize for TooSmallPadding {
-    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, usize>) -> usize {
+    fn mem_size_rec(&self, _flags: SizeFlags, _refs: &mut HashMap<usize, RefRecord>) -> usize {
         core::mem::size_of_val(&self.0)
     }
 }

--- a/mem_dbg/tests/test_unsized_shared.rs
+++ b/mem_dbg/tests/test_unsized_shared.rs
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests for `Rc`/`Arc` with unsized pointees (`str`, slices).
+
+#![cfg(feature = "std")]
+
+use anyhow::Result;
+use core::mem::{align_of, size_of};
+use mem_dbg::{DbgFlags, MemDbg, MemSize, SizeFlags};
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Size of the `RcInner`/`ArcInner` allocation: two-word header extended
+/// with the payload and padded to the allocation alignment, as computed by
+/// the standard library.
+fn shared_alloc_size(payload_size: usize, payload_align: usize) -> usize {
+    let align = align_of::<usize>().max(payload_align);
+    let header = (2 * size_of::<usize>()).next_multiple_of(payload_align);
+    (header + payload_size).next_multiple_of(align)
+}
+
+#[test]
+fn test_rc_str() -> Result<()> {
+    let rc: Rc<str> = Rc::from("hello");
+
+    // Without FOLLOW_RCS the handle is a fat pointer.
+    assert_eq!(rc.mem_size(SizeFlags::default()), size_of::<Rc<str>>());
+
+    // With FOLLOW_RCS the whole allocation is counted.
+    assert_eq!(
+        rc.mem_size(SizeFlags::FOLLOW_RCS),
+        size_of::<Rc<str>>() + shared_alloc_size(5, 1)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_arc_slice() -> Result<()> {
+    let arc: Arc<[u32]> = Arc::from(vec![1_u32, 2, 3, 4, 5]);
+
+    assert_eq!(arc.mem_size(SizeFlags::default()), size_of::<Arc<[u32]>>());
+    assert_eq!(
+        arc.mem_size(SizeFlags::FOLLOW_RCS),
+        size_of::<Arc<[u32]>>() + shared_alloc_size(5 * size_of::<u32>(), align_of::<u32>())
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rc_str_clones_deduplicated() -> Result<()> {
+    let rc: Rc<str> = Rc::from("hello");
+    let pair = (rc.clone(), rc);
+
+    assert_eq!(
+        pair.mem_size(SizeFlags::FOLLOW_RCS),
+        2 * size_of::<Rc<str>>() + shared_alloc_size(5, 1)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_arc_nonflat_slice_recurses() -> Result<()> {
+    let arc: Arc<[String]> = Arc::from(vec!["ab".to_owned(), "cdef".to_owned()]);
+
+    // The allocation plus the heap content of the strings.
+    assert_eq!(
+        arc.mem_size(SizeFlags::FOLLOW_RCS),
+        size_of::<Arc<[String]>>()
+            + shared_alloc_size(2 * size_of::<String>(), align_of::<String>())
+            + 2
+            + 4
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rc_str_mem_dbg() -> Result<()> {
+    let rc: Rc<str> = Rc::from("hello");
+    let mut output = String::new();
+    rc.mem_dbg_on(&mut output, DbgFlags::default() | DbgFlags::FOLLOW_RCS)?;
+    assert!(output.contains("@ 0x"), "missing address marker: {output}");
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #52 (merge that first; this PR builds on its cycle-breaking helpers).

## Problem

`mem_size` under `SizeFlags::FOLLOW_REFS` deduplicates followed references by thin pointer address alone. Two references can share an address while spanning different regions — a reference to a struct and a reference to its first field, or two overlapping slices. The result depended on encounter order:

```rust
let pair: (u64, u64) = (1, 2);
(&pair, &pair.0).mem_size(SizeFlags::FOLLOW_REFS) // 32 (correct)
(&pair.0, &pair).mem_size(SizeFlags::FOLLOW_REFS) // 24 (16-byte pair never counted)
```

## Fix

The deduplication map value is now a public `RefRecord { extent, size }`, where `extent` is `size_of_val` of the referent:

- a re-encountered address is skipped only if the recorded extent already covers the new referent;
- a strictly larger referent at the same base address is recursed again and **replaces** the record — it strictly contains the smaller one, so counting the larger extent once is exact;
- the zero-size sentinel inserted before recursing still breaks cycles, and a record left by a larger referent during recursion is never clobbered.

Shared-pointer recording (`Rc`/`Arc`) goes through the same helper for consistency.

## Compatibility

This changes the public `mem_size_rec` signature (`HashMap<usize, usize>` → `HashMap<usize, RefRecord>`), so manual implementations that spell out the map type must be updated (changelog entry under *Changed*); implementations that ignore the parameter are unaffected. The derive macros emit the new signature.

## Tests

New `test_overlapping_refs.rs` covers struct/first-field and overlapping-slice pairs in both encounter orders, plus the equal-extent dedup case. Existing cycle tests pass unchanged. Clippy clean, `no_std` and `no_std`+derive suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)