### PR TITLE
Deduplicate lock-guard targets under FOLLOW_REFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@
 
 ### Fixed
 
+- Under `SizeFlags::FOLLOW_REFS`, lock guards (`MutexGuard`,
+  `RwLockReadGuard`, `RwLockWriteGuard`) now record their target in the
+  same deduplication map as plain references, so several guards of the
+  same lock (or a guard and a reference to the same value) count the
+  target once. The guarded value is now counted in full, like `&T`,
+  rather than by its heap extras only.
+
 - Under `SizeFlags::FOLLOW_REFS`, two references sharing an address but
   spanning regions of different sizes (e.g., a reference to a struct and a
   reference to its first field, or overlapping slices) were deduplicated by

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1002,6 +1002,11 @@ impl<T: MemSize> MemSize for std::sync::RwLock<T> {
 /// Helper function to compute the size of a Deref pointer type,
 /// such as `MutexGuard`, `RwLockReadGuard`, `RwLockWriteGuard`.
 ///
+/// Under [`SizeFlags::FOLLOW_REFS`] the guarded value is recorded in the
+/// deduplication map exactly like a plain reference, so several guards of
+/// the same lock (or a guard and a reference to the same value) count the
+/// target once.
+///
 /// # Arguments
 ///
 /// * `obj` - The Deref pointer object.
@@ -1012,13 +1017,9 @@ fn deref_pointer_size<M>(obj: &M, flags: SizeFlags, refs: &mut HashMap<usize, Re
 where
     M: Deref<Target: MemSize + Sized>,
 {
+    let target = obj.deref();
+    record_followed_pointer_size(target, target as *const M::Target as usize, flags, refs);
     core::mem::size_of::<M>()
-        + if flags.contains(SizeFlags::FOLLOW_REFS) {
-            <M::Target as MemSize>::mem_size_rec(obj.deref(), flags, refs)
-                - core::mem::size_of::<M::Target>()
-        } else {
-            0
-        }
 }
 
 #[cfg(feature = "std")]

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-darwin.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -121,21 +121,21 @@ expression: output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.42% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.41% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    12 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    26 B   0.06% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    32 B   0.07% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.68% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
  3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
@@ -143,7 +143,7 @@ expression: output
  1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.15% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.06% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.05% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 6_716 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_406 B  10.12% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.03% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-darwin.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@aarch64-linux.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_0@x86_64.snap
@@ -2,4 +2,4 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-darwin.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -96,29 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -96,29 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -96,21 +96,21 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.42% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.41% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    12 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    26 B   0.06% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    32 B   0.07% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.68% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
  3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
@@ -118,7 +118,7 @@ expression: depth_output
  1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.15% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_1@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -96,29 +96,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.06% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.05% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 6_716 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_406 B  10.12% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.03% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-darwin.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_149 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_201 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.09% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.07% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.08% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    696 B   1.10% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_208 B   1.91% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
- 3_958 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
- 3_958 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_708 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
+ 3_958 B   6.26% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
+ 6_708 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.46% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
  6_406 B  10.14% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.05% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.60% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.59% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-44_665 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+44_693 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool [6B]
      4 B   0.01% ├╴character: char
@@ -121,21 +121,21 @@ expression: depth_output
      4 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
      8 B   0.02% ├╴layout: core::alloc::layout::Layout
      4 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_232 B  18.43% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_228 B  18.42% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_232 B  18.42% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_228 B  18.41% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     24 B   0.05% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      4 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      4 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     52 B   0.12% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     48 B   0.11% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
     64 B   0.14% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-     8 B   0.02% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    14 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    20 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    12 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    26 B   0.06% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    32 B   0.07% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     32 B   0.07% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    688 B   1.54% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     32 B   0.07% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
- 1_200 B   2.69% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
+ 1_200 B   2.68% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  2_414 B   5.40% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  2_414 B   5.40% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
  3_628 B   8.12% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
@@ -143,7 +143,7 @@ expression: depth_output
  1_092 B   2.44% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     12 B   0.03% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  1_884 B   4.22% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 3_658 B   8.19% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 3_658 B   8.19% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
- 5_432 B  12.16% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 3_658 B   8.18% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+ 5_432 B  12.15% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     64 B   0.14% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
@@ -2,7 +2,7 @@
 source: mem_dbg/tests/test_all_types_mem_dbg_insta.rs
 expression: depth_output
 ---
-63_221 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
+63_273 B 100.00% ⏺: test_all_types_mem_dbg_insta::all_types_helper::AllTypesStruct
      0 B   0.00% ├╴unit: ()
      1 B   0.00% ├╴boolean: bool
      4 B   0.01% ├╴character: char
@@ -121,29 +121,29 @@ expression: depth_output
      8 B   0.01% ├╴fn_ptr4: fn(u32, u64, i32, f64) -> bool
     16 B   0.03% ├╴layout: core::alloc::layout::Layout
      8 B   0.01% ├╴non_null: core::ptr::non_null::NonNull<i32>
- 8_264 B  13.07% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
- 8_256 B  13.06% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_264 B  13.06% ├╴buf_reader: std::io::buffered::bufreader::BufReader<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
+ 8_256 B  13.05% ├╴buf_writer: std::io::buffered::bufwriter::BufWriter<std::io::cursor::Cursor<alloc::vec::Vec<u8>>>
     36 B   0.06% ├╴cursor: std::io::cursor::Cursor<alloc::vec::Vec<u8>>
      8 B   0.01% ├╴arc: alloc::sync::Arc<i32>
      8 B   0.01% ├╴rc: alloc::rc::Rc<i32>
     92 B   0.15% ├╴vec_deque_nested: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<i32>>
     84 B   0.13% ├╴binary_heap_nested: alloc::collections::binary_heap::BinaryHeap<alloc::vec::Vec<i32>>
    116 B   0.18% ├╴linked_list_nested: alloc::collections::linked_list::LinkedList<alloc::vec::Vec<i32>>
-    16 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
-    22 B   0.03% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
-    28 B   0.04% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
+    20 B   0.03% ├╴mutex_guard: std::sync::poison::mutex::MutexGuard<i32>
+    46 B   0.07% ├╴rw_lock_read_guard: std::sync::poison::rwlock::RwLockReadGuard<alloc::string::String>
+    52 B   0.08% ├╴rw_lock_write_guard: std::sync::poison::rwlock::RwLockWriteGuard<alloc::string::String>
     48 B   0.08% ├╴hash_set_empty: std::collections::hash::set::HashSet<i32>
    704 B   1.11% ├╴hash_set_100: std::collections::hash::set::HashSet<i32>
     48 B   0.08% ├╴hash_map_empty: std::collections::hash::map::HashMap<i32, i32>
  1_216 B   1.92% ├╴hash_map_cc_100: std::collections::hash::map::HashMap<i32, i32>
  3_966 B   6.27% ├╴hash_map_cn_100: std::collections::hash::map::HashMap<i32, alloc::string::String>
  3_966 B   6.27% ├╴hash_map_nc_100: std::collections::hash::map::HashMap<alloc::string::String, i32>
- 6_716 B  10.62% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+ 6_716 B  10.61% ├╴hash_map_nn_100: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
     24 B   0.04% ├╴btree_set_empty: alloc::collections::btree::set::BTreeSet<i32>
  1_404 B   2.22% ├╴btree_set_100: alloc::collections::btree::set::BTreeSet<i32>
     24 B   0.04% ├╴btree_map_empty: alloc::collections::btree::map::BTreeMap<i32, i32>
  2_184 B   3.45% ├╴btree_map_cc_100: alloc::collections::btree::map::BTreeMap<i32, i32>
- 6_406 B  10.13% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
- 6_346 B  10.04% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
-10_484 B  16.58% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+ 6_406 B  10.12% ├╴btree_map_cn_100: alloc::collections::btree::map::BTreeMap<i32, alloc::string::String>
+ 6_346 B  10.03% ├╴btree_map_nc_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, i32>
+10_484 B  16.57% ├╴btree_map_nn_100: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
     72 B   0.11% ╰╴default_hasher: std::hash::random::DefaultHasher

--- a/mem_dbg/tests/test_guard_ref_dedup.rs
+++ b/mem_dbg/tests/test_guard_ref_dedup.rs
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests that lock guards deduplicate their target through the same map as
+//! plain references under `SizeFlags::FOLLOW_REFS`.
+
+#![cfg(feature = "std")]
+
+use anyhow::Result;
+use core::mem::size_of;
+use mem_dbg::{MemSize, SizeFlags};
+use std::sync::{RwLock, RwLockReadGuard};
+
+#[test]
+fn test_two_read_guards_count_target_once() -> Result<()> {
+    let lock = RwLock::new(vec![0_u8; 100]);
+    let g1 = lock.read().unwrap();
+    let g2 = lock.read().unwrap();
+
+    let guards = (&g1, &g2);
+    let size = guards.mem_size(SizeFlags::FOLLOW_REFS);
+
+    // Two references, two guards, and the guarded vector counted once.
+    let expected = 2 * size_of::<&RwLockReadGuard<'_, Vec<u8>>>()
+        + 2 * size_of::<RwLockReadGuard<'_, Vec<u8>>>()
+        + size_of::<Vec<u8>>()
+        + 100;
+    assert_eq!(size, expected);
+    Ok(())
+}
+
+#[test]
+fn test_guard_follows_target_like_a_reference() -> Result<()> {
+    let lock = RwLock::new(vec![0_u8; 100]);
+    let guard = lock.read().unwrap();
+
+    // Without FOLLOW_REFS the guard is a handle only.
+    assert_eq!(
+        guard.mem_size(SizeFlags::default()),
+        size_of::<RwLockReadGuard<'_, Vec<u8>>>()
+    );
+
+    // With FOLLOW_REFS the guarded value is counted in full, like `&T`.
+    assert_eq!(
+        guard.mem_size(SizeFlags::FOLLOW_REFS),
+        size_of::<RwLockReadGuard<'_, Vec<u8>>>() + size_of::<Vec<u8>>() + 100
+    );
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #53 (which stacks on #52).

## Problem

`deref_pointer_size` (used by `MutexGuard`, `RwLockReadGuard`, `RwLockWriteGuard`) added the guarded value's size inline, bypassing the deduplication map. Under `SizeFlags::FOLLOW_REFS`, two read guards of the same `RwLock` — or a guard plus a plain reference to the same value — counted the target twice, while two `&T` to the same target count it once. It also counted only the target's heap extras, not the full target, unlike `&T`.

## Fix

Guards now record their target through `record_followed_pointer_size`, keyed by target address, so the target is counted once and in full, consistently with plain references. Without `FOLLOW_REFS` guards remain handles, as before.

## Snapshots

The `follow_refs` all-types snapshots change accordingly (guard lines grow by the target's stack size; total +52 on 64-bit, +28 on x86). The aarch64-darwin snapshots were regenerated with `cargo insta`; the aarch64-linux/x86_64/x86 snapshots were updated by a script mirroring the separator formatter, validated byte-for-byte against the insta-accepted darwin output (same deltas, recomputed percentages and alignment). Please double-check on CI for those targets.

## Tests

New `test_guard_ref_dedup.rs`: two read guards of the same lock count the vector once; a single guard counts the full target like `&T`. Full suite, clippy, and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)