### PR TITLE
Support unsized pointees in Rc and Arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### New
 
+- `Rc<T>` and `Arc<T>` now support unsized pointees (`Rc<str>`,
+  `Arc<[T]>`, ...). The control-block allocation is measured by extending
+  the header layout with the layout of the pointed-to value, exactly like
+  the standard library computes it.
+
 - Added `MemSize`/`MemDbg` implementations, behind the `aliasable` feature,
   for the `aliasable` crate: `AliasableBox` mirrors `Box`, `AliasableVec`
   mirrors `Vec`, `AliasableString` mirrors `String`, and `AliasableMut`

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -414,8 +414,8 @@ impl<P: MemDbgImpl> MemDbgImpl for core::pin::Pin<P> {
 /// This implementation displays the referenced data with deduplication
 /// when FOLLOW_RCS is set.
 #[cfg(feature = "std")]
-impl<T: MemDbgImpl> MemDbgImpl for std::rc::Rc<T> {
-    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::rc::Rc::as_ptr(s) as usize);
+impl<T: ?Sized + MemDbgImpl> MemDbgImpl for std::rc::Rc<T> {
+    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::rc::Rc::as_ptr(s) as *const () as usize);
 }
 
 // Weak pointers are displayed as handles only.
@@ -428,8 +428,9 @@ impl<T: ?Sized> MemDbgImpl for std::rc::Weak<T> {}
 /// This implementation displays the referenced data with deduplication
 /// when FOLLOW_RCS is set.
 #[cfg(feature = "std")]
-impl<T: MemDbgImpl> MemDbgImpl for std::sync::Arc<T> {
-    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::sync::Arc::as_ptr(s) as usize);
+impl<T: ?Sized + MemDbgImpl> MemDbgImpl for std::sync::Arc<T> {
+    impl_mem_dbg_for_deref!(FOLLOW_RCS, |s| std::sync::Arc::as_ptr(s) as *const ()
+        as usize);
 }
 
 // Weak pointers are displayed as handles only.

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -348,7 +348,9 @@ impl<P: MemSize> MemSize for core::pin::Pin<P> {
 
 // Rc: uses map for deduplication when FOLLOW_RCS is set
 
-// Structure used to measure the size of RcInner in std
+// Structure used to measure the layout of std's RcInner header; only
+// instantiated as RcInner<()>, whose layout is extended with the layout of
+// the pointed-to value exactly like std::rc::Rc::allocate_for_layout does.
 #[cfg(feature = "std")]
 #[repr(C, align(2))]
 struct RcInner<T: ?Sized> {
@@ -361,26 +363,38 @@ struct RcInner<T: ?Sized> {
 /// `FOLLOW_RCS` is set, including its control-block header. A zero-size
 /// sentinel is inserted before recursing so that cycles terminate. Extents
 /// are handled as in [`record_followed_pointer_size`].
+///
+/// The allocation size is computed like the standard library computes it:
+/// the control-block header layout is extended with the layout of the
+/// pointed-to value and padded to alignment. This is exact for sized and
+/// unsized pointees alike.
 #[cfg(feature = "std")]
 #[inline(always)]
-fn record_followed_shared_size<T: MemSize>(
+fn record_followed_shared_size<T: ?Sized + MemSize>(
     inner: &T,
     ptr: usize,
-    inner_header_size: usize,
+    header_layout: core::alloc::Layout,
     flags: SizeFlags,
     refs: &mut HashMap<usize, RefRecord>,
 ) {
     if flags.contains(SizeFlags::FOLLOW_RCS) {
-        let extent = core::mem::size_of::<T>();
+        let extent = core::mem::size_of_val(inner);
         record_followed_size(ptr, extent, refs, |refs| {
-            inner_header_size + <T as MemSize>::mem_size_rec(inner, flags, refs)
-                - core::mem::size_of::<T>()
+            let alloc_size = header_layout
+                .extend(core::alloc::Layout::for_value(inner))
+                // Cannot overflow: the allocation exists.
+                .expect("layout overflow")
+                .0
+                .pad_to_align()
+                .size();
+            alloc_size - core::mem::size_of_val(inner)
+                + <T as MemSize>::mem_size_rec(inner, flags, refs)
         });
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> FlatType for std::rc::Rc<T> {
+impl<T: ?Sized> FlatType for std::rc::Rc<T> {
     type Flat = False;
 }
 
@@ -400,12 +414,12 @@ impl<T> FlatType for std::rc::Rc<T> {
 /// }
 /// ```
 #[cfg(feature = "std")]
-impl<T: MemSize> MemSize for std::rc::Rc<T> {
+impl<T: ?Sized + MemSize> MemSize for std::rc::Rc<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         record_followed_shared_size(
             self.as_ref(),
-            std::rc::Rc::as_ptr(self) as usize,
-            core::mem::size_of::<RcInner<T>>(),
+            std::rc::Rc::as_ptr(self) as *const () as usize,
+            core::alloc::Layout::new::<RcInner<()>>(),
             flags,
             refs,
         );
@@ -431,11 +445,13 @@ impl<T: ?Sized> MemSize for std::rc::Weak<T> {
 // Arc: uses map for deduplication when FOLLOW_RCS is set
 
 #[cfg(feature = "std")]
-impl<T> FlatType for std::sync::Arc<T> {
+impl<T: ?Sized> FlatType for std::sync::Arc<T> {
     type Flat = False;
 }
 
-// Structure used to measure the size of ArcInner in std
+// Structure used to measure the layout of std's ArcInner header; only
+// instantiated as ArcInner<()>, whose layout is extended with the layout of
+// the pointed-to value exactly like std::sync::Arc::allocate_for_layout does.
 #[cfg(feature = "std")]
 #[repr(C, align(2))]
 struct ArcInner<T: ?Sized> {
@@ -461,12 +477,12 @@ struct ArcInner<T: ?Sized> {
 /// }
 /// ```
 #[cfg(feature = "std")]
-impl<T: MemSize> MemSize for std::sync::Arc<T> {
+impl<T: ?Sized + MemSize> MemSize for std::sync::Arc<T> {
     fn mem_size_rec(&self, flags: SizeFlags, refs: &mut HashMap<usize, RefRecord>) -> usize {
         record_followed_shared_size(
             self.as_ref(),
-            std::sync::Arc::as_ptr(self) as usize,
-            core::mem::size_of::<ArcInner<T>>(),
+            std::sync::Arc::as_ptr(self) as *const () as usize,
+            core::alloc::Layout::new::<ArcInner<()>>(),
             flags,
             refs,
         );

--- a/mem_dbg/tests/test_unsized_shared.rs
+++ b/mem_dbg/tests/test_unsized_shared.rs
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests for `Rc`/`Arc` with unsized pointees (`str`, slices).
+
+#![cfg(feature = "std")]
+
+use anyhow::Result;
+use core::mem::{align_of, size_of};
+use mem_dbg::{DbgFlags, MemDbg, MemSize, SizeFlags};
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Size of the `RcInner`/`ArcInner` allocation: two-word header extended
+/// with the payload and padded to the allocation alignment, as computed by
+/// the standard library.
+fn shared_alloc_size(payload_size: usize, payload_align: usize) -> usize {
+    let align = align_of::<usize>().max(payload_align);
+    let header = (2 * size_of::<usize>()).next_multiple_of(payload_align);
+    (header + payload_size).next_multiple_of(align)
+}
+
+#[test]
+fn test_rc_str() -> Result<()> {
+    let rc: Rc<str> = Rc::from("hello");
+
+    // Without FOLLOW_RCS the handle is a fat pointer.
+    assert_eq!(rc.mem_size(SizeFlags::default()), size_of::<Rc<str>>());
+
+    // With FOLLOW_RCS the whole allocation is counted.
+    assert_eq!(
+        rc.mem_size(SizeFlags::FOLLOW_RCS),
+        size_of::<Rc<str>>() + shared_alloc_size(5, 1)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_arc_slice() -> Result<()> {
+    let arc: Arc<[u32]> = Arc::from(vec![1_u32, 2, 3, 4, 5]);
+
+    assert_eq!(arc.mem_size(SizeFlags::default()), size_of::<Arc<[u32]>>());
+    assert_eq!(
+        arc.mem_size(SizeFlags::FOLLOW_RCS),
+        size_of::<Arc<[u32]>>() + shared_alloc_size(5 * size_of::<u32>(), align_of::<u32>())
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rc_str_clones_deduplicated() -> Result<()> {
+    let rc: Rc<str> = Rc::from("hello");
+    let pair = (rc.clone(), rc);
+
+    assert_eq!(
+        pair.mem_size(SizeFlags::FOLLOW_RCS),
+        2 * size_of::<Rc<str>>() + shared_alloc_size(5, 1)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_arc_nonflat_slice_recurses() -> Result<()> {
+    let arc: Arc<[String]> = Arc::from(vec!["ab".to_owned(), "cdef".to_owned()]);
+
+    // The allocation plus the heap content of the strings.
+    assert_eq!(
+        arc.mem_size(SizeFlags::FOLLOW_RCS),
+        size_of::<Arc<[String]>>()
+            + shared_alloc_size(2 * size_of::<String>(), align_of::<String>())
+            + 2
+            + 4
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rc_str_mem_dbg() -> Result<()> {
+    let rc: Rc<str> = Rc::from("hello");
+    let mut output = String::new();
+    rc.mem_dbg_on(&mut output, DbgFlags::default() | DbgFlags::FOLLOW_RCS)?;
+    assert!(output.contains("@ 0x"), "missing address marker: {output}");
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #53.

## Problem

`MemSize`/`MemDbgImpl` for `Rc<T>` and `Arc<T>` required `T: Sized`, so `Rc<str>`, `Arc<[T]>`, and `Arc<dyn ...>` had no implementations — while `Box<T: ?Sized>` works.

## Fix

- The impls are now `T: ?Sized` (`FlatType`, `MemSize`, `MemDbgImpl`).
- The control-block allocation is measured as `Layout::new::<RcInner<()>>().extend(Layout::for_value(inner)).pad_to_align().size()` — the exact computation `std`'s `allocate_for_layout` performs, correct for sized and unsized pointees alike. For sized pointees this is identical to the previous `size_of::<RcInner<T>>()` mirror value, so reported sizes do not change.
- Dedup keys thin-cast fat pointers (`as *const () as usize`).

## Tests

New `test_unsized_shared.rs`: `Rc<str>` and `Arc<[u32]>` allocation sizes under `FOLLOW_RCS`, clone dedup, recursion into non-flat `Arc<[String]>`, and a `MemDbg` smoke test. Full suite, clippy, fmt, and `no_std` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)