### PR TITLE
Render Option/Result payloads as labeled MemDbg children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [0.4.3] - unreleased
 
+### Fixed
+
+- `Option` and `Result` now render their active payload as a labeled
+  child (`Some`, `Ok`, `Err`) in `MemDbg` output, consistently with
+  `ControlFlow`, `Poll`, `Bound`, and `Reverse`. Previously they rendered
+  no children at all, even though `MemSize` counts the payload.
+
 ### Changed
 
 - Container size computation no longer dispatches through the hidden

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -163,13 +163,74 @@ impl<T: ?Sized> MemDbgImpl for *const T {}
 
 impl<T: ?Sized> MemDbgImpl for *mut T {}
 
-// Option
+// Option and Result render the active payload as a labeled child, like
+// the other sum types below (ControlFlow, Poll, Bound).
 
-impl<T: MemDbgImpl> MemDbgImpl for Option<T> {}
+impl<T: MemDbgImpl> MemDbgImpl for Option<T> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        _is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        match self {
+            Some(t) => t._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Some"),
+                true,
+                core::mem::size_of::<T>(),
+                flags,
+                dbg_refs,
+            ),
+            None => Ok(()),
+        }
+    }
+}
 
-// Result
-
-impl<T: MemDbgImpl, E: MemDbgImpl> MemDbgImpl for Result<T, E> {}
+impl<T: MemDbgImpl, E: MemDbgImpl> MemDbgImpl for Result<T, E> {
+    fn _mem_dbg_rec_on(
+        &self,
+        writer: &mut impl core::fmt::Write,
+        total_size: usize,
+        max_depth: usize,
+        prefix: &mut String,
+        _is_last: bool,
+        flags: DbgFlags,
+        dbg_refs: &mut HashSet<usize>,
+    ) -> core::fmt::Result {
+        match self {
+            Ok(t) => t._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Ok"),
+                true,
+                core::mem::size_of::<T>(),
+                flags,
+                dbg_refs,
+            ),
+            Err(e) => e._mem_dbg_depth_on(
+                writer,
+                total_size,
+                max_depth,
+                prefix,
+                Some("Err"),
+                true,
+                core::mem::size_of::<E>(),
+                flags,
+                dbg_refs,
+            ),
+        }
+    }
+}
 
 // Sum/newtype wrappers delegate debug traversal to the active payload only.
 

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86.snap
@@ -49,6 +49,7 @@ expression: output
      8 B   0.02% ├╴reference: &str
      4 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     12 B   0.02% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity@x86_64.snap
@@ -49,6 +49,7 @@ expression: output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86.snap
@@ -49,6 +49,7 @@ expression: depth_output
      8 B   0.02% ├╴reference: &str
      4 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     12 B   0.02% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     32 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__capacity_depth_2@x86_64.snap
@@ -49,6 +49,7 @@ expression: depth_output
     16 B   0.02% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.02% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.06% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: output
     16 B   0.03% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: output
     16 B   0.03% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86.snap
@@ -49,6 +49,7 @@ expression: output
      8 B   0.02% ├╴reference: &str
      4 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     12 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default@x86_64.snap
@@ -49,6 +49,7 @@ expression: output
     16 B   0.03% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: depth_output
     16 B   0.03% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: depth_output
     16 B   0.03% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86.snap
@@ -49,6 +49,7 @@ expression: depth_output
      8 B   0.02% ├╴reference: &str
      4 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     12 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__default_depth_2@x86_64.snap
@@ -49,6 +49,7 @@ expression: depth_output
     16 B   0.03% ├╴reference: &str
      8 B   0.01% ├╴mut_reference: &mut i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: output
    16 B ├╴reference
     8 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    24 B ├╴opt_none
    16 B ├╴boxed
    44 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: output
    16 B ├╴reference
     8 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    24 B ├╴opt_none
    16 B ├╴boxed
    44 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86.snap
@@ -49,6 +49,7 @@ expression: output
     8 B ├╴reference
     4 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    12 B ├╴opt_none
    12 B ├╴boxed
    32 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty@x86_64.snap
@@ -49,6 +49,7 @@ expression: output
    16 B ├╴reference
     8 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    24 B ├╴opt_none
    16 B ├╴boxed
    44 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: depth_output
    16 B ├╴reference
     8 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    24 B ├╴opt_none
    16 B ├╴boxed
    44 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: depth_output
    16 B ├╴reference
     8 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    24 B ├╴opt_none
    16 B ├╴boxed
    44 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86.snap
@@ -49,6 +49,7 @@ expression: depth_output
     8 B ├╴reference
     4 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    12 B ├╴opt_none
    12 B ├╴boxed
    32 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__empty_depth_2@x86_64.snap
@@ -49,6 +49,7 @@ expression: depth_output
    16 B ├╴reference
     8 B ├╴mut_reference
     8 B ├╴opt_some
+    4 B │ ╰╴Some
    24 B ├╴opt_none
    16 B ├╴boxed
    44 B ├╴vec

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-darwin.snap
@@ -51,6 +51,7 @@ expression: output
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@aarch64-linux.snap
@@ -51,6 +51,7 @@ expression: output
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86.snap
@@ -51,6 +51,7 @@ expression: output
      8 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     12 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs@x86_64.snap
@@ -51,6 +51,7 @@ expression: output
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-darwin.snap
@@ -51,6 +51,7 @@ expression: depth_output
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@aarch64-linux.snap
@@ -51,6 +51,7 @@ expression: depth_output
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86.snap
@@ -51,6 +51,7 @@ expression: depth_output
      8 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.02% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     12 B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
     12 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     32 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__follow_refs_depth_2@x86_64.snap
@@ -51,6 +51,7 @@ expression: depth_output
     12 B   0.02% ├╴mut_reference: &mut i32 @ 0x[ADDR_2]
      4 B   0.01% │ ├╴: i32
      8 B   0.01% ├╴opt_some: core::option::Option<i32>
+     4 B   0.01% │ ╰╴Some: i32
     24 B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
     16 B   0.03% ├╴boxed: alloc::boxed::Box<u64>
     44 B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: output
    16  B   0.03% ├╴reference: &str
     8  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.01% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: output
    16  B   0.03% ├╴reference: &str
     8  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.01% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86.snap
@@ -49,6 +49,7 @@ expression: output
     8  B   0.02% ├╴reference: &str
     4  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.02% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    12  B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
    12  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    32  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize@x86_64.snap
@@ -49,6 +49,7 @@ expression: output
    16  B   0.03% ├╴reference: &str
     8  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.01% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-darwin.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-darwin.snap
@@ -49,6 +49,7 @@ expression: depth_output
    16  B   0.03% ├╴reference: &str
     8  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.01% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-linux.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@aarch64-linux.snap
@@ -49,6 +49,7 @@ expression: depth_output
    16  B   0.03% ├╴reference: &str
     8  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.01% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86.snap
@@ -49,6 +49,7 @@ expression: depth_output
     8  B   0.02% ├╴reference: &str
     4  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.02% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    12  B   0.03% ├╴opt_none: core::option::Option<alloc::string::String>
    12  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    32  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
+++ b/mem_dbg/tests/snapshots/test_all_types_mem_dbg_insta__humanize_depth_2@x86_64.snap
@@ -49,6 +49,7 @@ expression: depth_output
    16  B   0.03% ├╴reference: &str
     8  B   0.01% ├╴mut_reference: &mut i32
     8  B   0.01% ├╴opt_some: core::option::Option<i32>
+    4  B   0.01% │ ╰╴Some: i32
    24  B   0.04% ├╴opt_none: core::option::Option<alloc::string::String>
    16  B   0.03% ├╴boxed: alloc::boxed::Box<u64>
    44  B   0.07% ├╴vec: alloc::vec::Vec<i32>

--- a/mem_dbg/tests/test_option_result_dbg.rs
+++ b/mem_dbg/tests/test_option_result_dbg.rs
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests that `Option` and `Result` render their active payload as a
+//! labeled child, consistently with `ControlFlow`, `Poll`, and `Bound`.
+
+use anyhow::Result;
+use mem_dbg::{DbgFlags, MemDbg};
+
+#[test]
+fn test_option_some_renders_child() -> Result<()> {
+    let value: Option<u32> = Some(7);
+    let mut output = String::new();
+    value.mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_eq!(output, "8 B ⏺\n4 B ╰╴Some\n");
+    Ok(())
+}
+
+#[test]
+fn test_option_none_renders_no_child() -> Result<()> {
+    let value: Option<u32> = None;
+    let mut output = String::new();
+    value.mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_eq!(output, "8 B ⏺\n");
+    Ok(())
+}
+
+#[test]
+fn test_result_ok_renders_child() -> Result<()> {
+    let value: core::result::Result<u32, u8> = Ok(7);
+    let mut output = String::new();
+    value.mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_eq!(output, "8 B ⏺\n4 B ╰╴Ok\n");
+    Ok(())
+}
+
+#[test]
+fn test_result_err_renders_child() -> Result<()> {
+    let value: core::result::Result<u32, u8> = Err(3);
+    let mut output = String::new();
+    value.mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_eq!(output, "8 B ⏺\n1 B ╰╴Err\n");
+    Ok(())
+}
+
+#[test]
+fn test_nested_option_renders_chain() -> Result<()> {
+    let value: Option<Option<u32>> = Some(Some(7));
+    let mut output = String::new();
+    value.mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_eq!(output, "8 B ⏺\n8 B ╰╴Some\n4 B   ╰╴Some\n");
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`ControlFlow`, `Poll`, `Bound`, and `Reverse` render their active payload as a labeled child (the 0.4.2 fix), but `Option` and `Result` — by far the most common sum types — still had empty `MemDbgImpl` impls: `Option<Vec<u8>>` hid its payload while `Poll<Vec<u8>>` showed it, even though `MemSize` counts the payload either way.

## Fix

`Option<T>` renders a `Some` child when populated; `Result<T, E>` renders `Ok`/`Err`. `None` renders nothing, matching `Poll::Pending`/`Bound::Unbounded`.

```text
8 B ⏺: core::option::Option<u32>
4 B ╰╴Some: u32
```

## Snapshots

The all-types helper has `opt_some: Option<i32>`, so each flag variant gains one `Some: i32` child line (full and depth-2 snapshots; totals unchanged). aarch64-darwin was regenerated with `cargo insta`; aarch64-linux/x86_64/x86 were patched with a script that recomputes the size/percentage columns from each file's own total, validated byte-for-byte against the insta-accepted darwin output. Please double-check on CI for those targets.

## Tests

New `test_option_result_dbg.rs` with exact-output assertions (arch-portable sizes) for `Some`/`None`/`Ok`/`Err` and nested `Option<Option<u32>>`. Full suite, clippy, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)