### PR TITLE
Make Layout's MemDbgImpl available under no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [0.4.3] - unreleased
 
+### Fixed
+
+- The `MemDbgImpl` implementation for `core::alloc::Layout` was gated
+  behind the `std` feature, while its `MemSize` implementation was not:
+  under `no_std`, a `Layout` field made `#[derive(MemDbg)]` fail. The
+  implementation is now available unconditionally, like the type.
+
 ### Changed
 
 - Container size computation no longer dispatches through the hidden

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -602,10 +602,9 @@ impl MemDbgImpl for std::collections::hash_map::RandomState {
 
 // alloc
 
-#[cfg(feature = "std")]
 impl MemDbgImpl for core::alloc::Layout {
-    // Layout is size + align, but align is unstable so we can't recurse
-    // on that, nor implement memdbg or memsize for that :)
+    // Layout is a flat type (size and alignment); its fields are private,
+    // and there is nothing worth recursing into.
 }
 
 // Ranges


### PR DESCRIPTION
`core::alloc::Layout` has an unconditional `MemSize` implementation, but its `MemDbgImpl` was `#[cfg(feature = "std")]` — so under `no_std` a `Layout` field satisfied `MemSize` but failed the `MemDbgImpl` bound of `#[derive(MemDbg)]`. `Layout` is a `core` type; there is no reason to gate it.

Also updates the stale comment claiming `Layout::align` is unstable (it has been stable for years; the leaf rendering is because the fields are private and flat, not because of stability).

Note: the working tree in the main checkout has an uncommitted edit doing the same gate removal — this PR supersedes it and also fixes the comment.

Verified: `std`, `no_std`, and `no_std`+derive builds/tests clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)