### PR TITLE
Implement network and time types via core, add their MemDbgImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   under `no_std`, a `Layout` field made `#[derive(MemDbg)]` fail. The
   implementation is now available unconditionally, like the type.
 
+- The network address types and `Duration` are now implemented via
+  `core::net`/`core::time`, so they are available under `no_std`
+  (previously they were gated behind the `std` feature). Moreover, the
+  network and time types had no `MemDbgImpl` implementation at all, so a
+  field of one of these types made `#[derive(MemDbg)]` fail; they are now
+  leaf types for `MemDbg` too.
+
 ### Changed
 
 - Container size computation no longer dispatches through the hidden

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -1055,6 +1055,27 @@ impl<T: MemDbgImpl> MemDbgImpl for std::sync::RwLockWriteGuard<'_, T> {
     }
 }
 
+// Network and time: flat leaf types. The network types and Duration are
+// available under no_std (core::net, core::time); the clock-backed types
+// need std.
+
+impl_mem_dbg!(
+    core::net::Ipv4Addr,
+    core::net::Ipv6Addr,
+    core::net::IpAddr,
+    core::net::SocketAddrV4,
+    core::net::SocketAddrV6,
+    core::net::SocketAddr,
+    core::time::Duration
+);
+
+#[cfg(feature = "std")]
+impl_mem_dbg!(
+    std::time::Instant,
+    std::time::SystemTime,
+    std::time::SystemTimeError
+);
+
 // Os stuff
 
 #[cfg(feature = "std")]

--- a/mem_dbg/src/impl_mem_size.rs
+++ b/mem_dbg/src/impl_mem_size.rs
@@ -1128,21 +1128,22 @@ impl<T: MemSize> MemSize for std::io::Cursor<T> {
     }
 }
 
-// IpAddr
-#[cfg(feature = "std")]
+// IpAddr: these types live in core::net (stable since Rust 1.77), so they
+// are available under no_std; std::net re-exports them.
 impl_size_of!(True;
-    std::net::Ipv4Addr,
-    std::net::Ipv6Addr,
-    std::net::IpAddr,
-    std::net::SocketAddrV4,
-    std::net::SocketAddrV6,
-    std::net::SocketAddr
+    core::net::Ipv4Addr,
+    core::net::Ipv6Addr,
+    core::net::IpAddr,
+    core::net::SocketAddrV4,
+    core::net::SocketAddrV6,
+    core::net::SocketAddr
 );
 
-// Time
+// Time: Duration lives in core::time; the clock-backed types need std.
+impl_size_of!(True; core::time::Duration);
+
 #[cfg(feature = "std")]
 impl_size_of!(True;
-    std::time::Duration,
     std::time::Instant,
     std::time::SystemTime,
     std::time::SystemTimeError

--- a/mem_dbg/tests/test_net_time_dbg.rs
+++ b/mem_dbg/tests/test_net_time_dbg.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests that network and time types work with both `MemSize` and
+//! `MemDbg`, including inside derived structures.
+
+#![cfg(feature = "derive")]
+
+use anyhow::Result;
+use core::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use core::time::Duration;
+use mem_dbg::{DbgFlags, MemDbg, MemSize, SizeFlags};
+
+#[derive(MemSize, MemDbg)]
+#[mem_size(flat)]
+struct NetTime {
+    addr: IpAddr,
+    socket: SocketAddr,
+    duration: Duration,
+}
+
+#[test]
+fn test_net_time_derive() -> Result<()> {
+    let value = NetTime {
+        addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        socket: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80)),
+        duration: Duration::from_secs(1),
+    };
+
+    assert_eq!(
+        value.mem_size(SizeFlags::default()),
+        core::mem::size_of::<NetTime>()
+    );
+
+    let mut output = String::new();
+    value.mem_dbg_on(&mut output, DbgFlags::default())?;
+    assert!(output.contains("duration"));
+    Ok(())
+}


### PR DESCRIPTION
## Problems

1. `Ipv4Addr`/`Ipv6Addr`/`IpAddr`/`SocketAddr*` and `Duration` were gated behind the `std` feature, but they live in `core::net` (stable 1.77 < MSRV 1.85) and `core::time` — `no_std` users lost them for no reason.
2. None of the network/time types had a `MemDbgImpl` implementation at all, so a struct containing, say, a `Duration` failed `#[derive(MemDbg)]` bounds even under `std` — despite `MemSize` support existing since 0.2.1.

## Fix

- `MemSize` impls moved to `core::net`/`core::time` paths, unconditional (`std::net`/`std::time` re-export the same types, so nothing changes for `std` users).
- Added leaf `MemDbgImpl` impls for all of them. `Instant`, `SystemTime`, `SystemTimeError` stay `std`-gated (clock-backed).

## Tests

New `test_net_time_dbg.rs` derives `MemSize`+`MemDbg` on a struct with `IpAddr`, `SocketAddr`, and `Duration` fields and checks size and rendering. Full suite, `no_std`, clippy, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)