### PR TITLE
Break tuple field-offset ties by size in MemDbg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [0.4.3] - unreleased
 
+### Fixed
+
+- The tuple `MemDbg` implementation now breaks field-offset ties by size,
+  so zero-sized fields sharing an offset with a non-zero-sized field are
+  not attributed spurious padding. This mirrors the tie-breaking already
+  performed by the derive macro since 0.4.1.
+
 ### Changed
 
 - Container size computation no longer dispatches through the hidden

--- a/mem_dbg/src/impl_mem_dbg.rs
+++ b/mem_dbg/src/impl_mem_dbg.rs
@@ -501,23 +501,29 @@ macro_rules! impl_tuples_muncher {
                 let mut _max_idx = $idx;
                 $(_max_idx = _max_idx.max($nidx);)*
 
-                // Build the (field-index, field-offset) array on the stack.
+                // Build the (field-index, field-offset, field-size) array on
+                // the stack.
                 let mut id_sizes = [
-                    ($idx, core::mem::offset_of!($tty, $idx)),
-                    $(($nidx, core::mem::offset_of!($tty, $nidx)),)*
+                    ($idx, core::mem::offset_of!($tty, $idx), core::mem::size_of::<$ty>()),
+                    $(($nidx, core::mem::offset_of!($tty, $nidx), core::mem::size_of::<$nty>()),)*
                 ];
                 let n = id_sizes.len();
                 let total_size_self = core::mem::size_of::<Self>();
 
                 // Sort by offset to compute padded sizes via consecutive
                 // offset diffs; the last field stretches to `size_of::<Self>()`.
-                id_sizes.sort_by_key(|x| x.1);
+                // Ties are broken by size, so ZSTs come before non-ZSTs at the
+                // same offset (mirroring the derive macro), and then by index,
+                // which keeps the unstable sort deterministic.
+                id_sizes.sort_unstable_by(|a, b| {
+                    a.1.cmp(&b.1).then(a.2.cmp(&b.2)).then(a.0.cmp(&b.0))
+                });
                 for i in 0..n - 1 {
                     id_sizes[i].1 = id_sizes[i + 1].1 - id_sizes[i].1;
                 }
                 id_sizes[n - 1].1 = total_size_self - id_sizes[n - 1].1;
                 // Restore declaration order so we can index by field number.
-                id_sizes.sort_by_key(|x| x.0);
+                id_sizes.sort_unstable_by_key(|x| x.0);
 
                 self.$idx._mem_dbg_depth_on(writer, total_size, max_depth, prefix, Some(stringify!($idx)), $idx == _max_idx, id_sizes[$idx].1, flags, dbg_refs)?;
                 $(

--- a/mem_dbg/tests/test_tuple_zst_padding.rs
+++ b/mem_dbg/tests/test_tuple_zst_padding.rs
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Tests that zero-sized tuple fields are not attributed spurious padding,
+//! whatever offset the compiler assigns them.
+
+use anyhow::Result;
+use mem_dbg::{DbgFlags, MemDbg};
+
+fn assert_no_padding(output: &str) -> Result<()> {
+    assert!(
+        !output.contains('['),
+        "spurious padding annotation:\n{output}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_zst_tuples_show_no_padding() -> Result<()> {
+    // There is no real padding in any of these tuples, so no `[..B]`
+    // annotation must appear, wherever the compiler places the ZSTs.
+    let mut output = String::new();
+    (1_u64, ()).mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_no_padding(&output)?;
+
+    output.clear();
+    ((), 1_u64).mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_no_padding(&output)?;
+
+    output.clear();
+    ((), (), 1_u64).mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_no_padding(&output)?;
+
+    output.clear();
+    (1_u32, (), 2_u32, ()).mem_dbg_on(&mut output, DbgFlags::empty())?;
+    assert_no_padding(&output)?;
+    Ok(())
+}


### PR DESCRIPTION
The 0.4.1 fix "panic due to non-ZST being sorted by offset before a ZST in the same position" added a size tie-break to the field-offset sort in the **derive** macro, but the **tuple** `MemDbgImpl` was never updated: it sorts by offset alone, so whenever the compiler places a ZST at the same offset as a non-ZST tuple field, padding can be attributed to the wrong field (e.g. a `[8B]` marker on a `()` field).

Current rustc happens to place tuple ZSTs harmlessly, so this is latent rather than observed — but it is layout-dependent, and the derive and tuple paths should agree. The sort now uses (offset, size, index), identical semantics to the derive's stable (offset, size) sort, while remaining deterministic with `sort_unstable_by` (no `alloc` dependency).

Adds `test_tuple_zst_padding.rs` asserting that no spurious `[..B]` annotation appears for ZST-bearing tuples, wherever the compiler places them. Full suite, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)